### PR TITLE
Adding postfix expressions (++ and --) - changed evaluation order to be more human friendly (appears left to right now)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -203,11 +203,16 @@ func (i InfixExpression) PrettyPrint(out *PrintState) *PrintState {
 	if out.ExpressionLevel > 0 { // TODO only add parens if precedence requires it.
 		out.Print("(")
 	}
-	out.ExpressionLevel++
+	isAssign := (i.Token.Type() == token.ASSIGN)
+	if !isAssign {
+		out.ExpressionLevel++
+	}
 	i.Left.PrettyPrint(out)
 	out.Print(" ", i.Literal(), " ")
 	i.Right.PrettyPrint(out)
-	out.ExpressionLevel--
+	if !isAssign {
+		out.ExpressionLevel--
+	}
 	if out.ExpressionLevel > 0 {
 		out.Print(")")
 	}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -178,16 +178,14 @@ func (p PrefixExpression) PrettyPrint(out *PrintState) *PrintState {
 
 type PostfixExpression struct {
 	Base
-	Left Node
+	Prev *token.Token
 }
 
 func (p PostfixExpression) PrettyPrint(out *PrintState) *PrintState {
 	if out.ExpressionLevel > 0 {
 		out.Print("(")
 	}
-	out.ExpressionLevel++ // comment out for !(-a) to normalize to !-a
-	p.Left.PrettyPrint(out)
-	out.ExpressionLevel--
+	out.Print(p.Prev.Literal())
 	out.Print(p.Literal())
 	if out.ExpressionLevel > 0 {
 		out.Print(")")

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -176,6 +176,25 @@ func (p PrefixExpression) PrettyPrint(out *PrintState) *PrintState {
 	return out
 }
 
+type PostfixExpression struct {
+	Base
+	Left Node
+}
+
+func (p PostfixExpression) PrettyPrint(out *PrintState) *PrintState {
+	if out.ExpressionLevel > 0 {
+		out.Print("(")
+	}
+	out.ExpressionLevel++ // comment out for !(-a) to normalize to !-a
+	p.Left.PrettyPrint(out)
+	out.ExpressionLevel--
+	out.Print(p.Literal())
+	if out.ExpressionLevel > 0 {
+		out.Print(")")
+	}
+	return out
+}
+
 type InfixExpression struct {
 	Base
 	Left  Node

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -119,11 +119,13 @@ func (s *State) evalInternal(node any) object.Object {
 		return s.evalPostfixExpression(node)
 	case *ast.InfixExpression:
 		log.LogVf("eval infix %s", node.DebugString())
-		right := s.Eval(node.Right) // need to unwrap "return"
+		// Eval and not evalInternal because we need to unwrap "return".
 		if node.Literal() == "=" {
+			right := s.Eval(node.Right)
 			return s.evalAssignment(right, node)
 		}
 		left := s.Eval(node.Left)
+		right := s.Eval(node.Right)
 		return s.evalInfixExpression(node.Type(), left, right)
 
 	case *ast.IntegerLiteral:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -120,10 +120,10 @@ func (s *State) evalInternal(node any) object.Object {
 	case *ast.InfixExpression:
 		log.LogVf("eval infix %s", node.DebugString())
 		// Eval and not evalInternal because we need to unwrap "return".
-		if node.Literal() == "=" {
-			right := s.Eval(node.Right)
-			return s.evalAssignment(right, node)
+		if node.Token.Type() == token.ASSIGN {
+			return s.evalAssignment(s.Eval(node.Right), node)
 		}
+		// Humans expect left to right evaluations.
 		left := s.Eval(node.Left)
 		right := s.Eval(node.Right)
 		return s.evalInfixExpression(node.Type(), left, right)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -76,13 +76,22 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	if !ok {
 		return object.Error{Value: "<identifier not found: " + id + ">"}
 	}
+	var toAdd int64
 	switch node.Type() { //nolint:exhaustive // we have default.
 	case token.INCR:
-		s.env.Set(id, object.Integer{Value: val.(object.Integer).Value + 1})
+		toAdd = 1
 	case token.DECR:
-		s.env.Set(id, object.Integer{Value: val.(object.Integer).Value - 1})
+		toAdd = -1
 	default:
 		return object.Error{Value: "unknown postfix operator: " + node.Type().String()}
+	}
+	switch val := val.(type) {
+	case object.Integer:
+		s.env.Set(id, object.Integer{Value: val.Value + toAdd})
+	case object.Float:
+		s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)})
+	default:
+		return object.Error{Value: "can't increment/decrement " + val.Type().String()}
 	}
 	return val
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -39,6 +39,11 @@ func TestEvalIntegerExpression(t *testing.T) {
 		{"20 % -5", 0},
 		{"-21 % 5", -1},
 		{`fact = func(n) {if (n<2) {return 1} n*fact(n-1)}; fact(5)`, 120},
+		{`a=2; b=3; r=a+5*b++`, 17},
+		{`a=2; b=3; r=a+5*b++;b`, 4},
+		{`a=2; b=3; r=a+5*(b++)+b;`, 20}, // because that + b is evaluated before the deeper b++ - not well defined behavior.
+		{`a=2; b=3; r=b+5*(b++)+a;`, 21}, // because that solo b is evaluated last, after the b++ - not well defined behavior.
+		{`a=2; b=3; r=b+5*b+++a;`, 21},   // parantheses are not technically needed here though... this is rather un readable.
 	}
 
 	for i, tt := range tests {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -41,9 +41,9 @@ func TestEvalIntegerExpression(t *testing.T) {
 		{`fact = func(n) {if (n<2) {return 1} n*fact(n-1)}; fact(5)`, 120},
 		{`a=2; b=3; r=a+5*b++`, 17},
 		{`a=2; b=3; r=a+5*b++;b`, 4},
-		{`a=2; b=3; r=a+5*(b++)+b;`, 20}, // because that + b is evaluated before the deeper b++ - not well defined behavior.
-		{`a=2; b=3; r=b+5*(b++)+a;`, 21}, // because that solo b is evaluated last, after the b++ - not well defined behavior.
-		{`a=2; b=3; r=b+5*b+++a;`, 21},   // parantheses are not technically needed here though... this is rather un readable.
+		{`a=2; b=3; r=a+5*(b++)+b;`, 21}, // left to right eval, yet not that not well defined behavior.
+		{`a=2; b=3; r=b+5*(b++)+a;`, 20}, // because that solo b is evaluated last, after the b++ - not well defined behavior.
+		{`a=2; b=3; r=a+5*b+++b;`, 21},   // parentheses are not technically needed here though... this is rather un readable.
 	}
 
 	for i, tt := range tests {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -709,6 +709,7 @@ func TestEvalFloatExpression(t *testing.T) {
 		{".3", 0.3},
 		{"0.5*3", 1.5},
 		{"0.5*6", 3},
+		{`a=3.1; a--; a`, 2.1},
 	}
 
 	for i, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -35,8 +35,14 @@ func (l *Lexer) NextToken() *token.Token {
 			return token.ConstantTokenStr(literal)
 		}
 		return token.ConstantTokenChar(ch)
-
-	case '%', '*', '+', ';', ',', '{', '}', '(', ')', '[', ']', '-':
+	case '+', '-':
+		if l.peekChar() == ch {
+			nextChar := l.readChar()
+			literal := string(ch) + string(nextChar) // TODO: consider making a ContantTokenChar2 instead of making a string
+			return token.ConstantTokenStr(literal)   // increment/decrement
+		}
+		return token.ConstantTokenChar(ch)
+	case '%', '*', ';', ',', '{', '}', '(', ')', '[', ']':
 		// TODO maybe reorder so it's a continuous range for pure single character tokens
 		return token.ConstantTokenChar(ch)
 	case '/':

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -37,6 +37,8 @@ return // nil return
 macro(x, y) { x + y }
 a3:=5
 4>=3.1
+i++
+j--
 @
 `
 
@@ -151,6 +153,10 @@ a3:=5
 		{token.INT, "4"},
 		{token.GTEQ, ">="},
 		{token.FLOAT, "3.1"},
+		{token.IDENT, "i"},
+		{token.INCR, "++"},
+		{token.IDENT, "j"},
+		{token.DECR, "--"},
 		{token.ILLEGAL, "@"},
 		{token.EOF, ""},
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,7 +21,6 @@ const (
 	SUM         // +
 	PRODUCT     // *
 	PREFIX      // -X or !X
-	POSTFIX     // X++, X--
 	CALL        // myFunction(X)
 	INDEX       // array[index]
 )
@@ -364,8 +363,6 @@ var precedences = map[token.Type]Priority{
 	token.PERCENT:  PRODUCT,
 	token.LPAREN:   CALL,
 	token.LBRACKET: INDEX,
-	token.INCR:     POSTFIX,
-	token.DECR:     POSTFIX,
 }
 
 func (p *Parser) peekPrecedence() Priority {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -246,10 +246,6 @@ func (p *Parser) noPrefixParseFnError(t token.Type) {
 
 func (p *Parser) parseExpression(precedence Priority) ast.Node {
 	log.Debugf("parseExpression: %s precedence %s", p.curToken.DebugString(), precedence)
-	postfix := p.postfixParseFns[p.curToken.Type()]
-	if postfix != nil {
-		return (postfix())
-	}
 	prefix := p.prefixParseFns[p.curToken.Type()]
 	if prefix == nil {
 		p.noPrefixParseFnError(p.curToken.Type())
@@ -277,6 +273,12 @@ func (p *Parser) parseExpression(precedence Priority) ast.Node {
 }
 
 func (p *Parser) parseIdentifier() ast.Node {
+	postfix := p.postfixParseFns[p.peekToken.Type()]
+	if postfix != nil {
+		log.LogVf("parseIdentifier: next is a postfix for %s: %s", p.curToken.DebugString(), p.peekToken.DebugString())
+		p.nextToken()
+		return postfix()
+	}
 	i := &ast.Identifier{}
 	i.Token = p.curToken
 	return i
@@ -344,9 +346,6 @@ func (p *Parser) parsePostfixExpression() ast.Node {
 	expression := &ast.PostfixExpression{}
 	expression.Token = p.curToken
 	expression.Prev = p.prevToken
-
-	p.nextToken()
-
 	return expression
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -183,7 +183,7 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 		},
 		{
 			"x = 41 * 6",
-			"x = (41 * 6)",
+			"x = 41 * 6", // = doesn't trigger expression level so it's more natural to read.
 		},
 		{
 			"foo = func(a,b) {return a+b}",

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -18,7 +18,7 @@ foobar = 838383;
 	p := parser.New(l)
 
 	program := p.ParseProgram()
-	checkParserErrors(t, p)
+	checkParserErrors(t, input, p)
 	if program == nil {
 		t.Fatalf("ParseProgram() returned nil")
 	}
@@ -43,13 +43,13 @@ foobar = 838383;
 	}
 }
 
-func checkParserErrors(t *testing.T, p *parser.Parser) {
+func checkParserErrors(t *testing.T, input string, p *parser.Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {
 		return
 	}
 
-	t.Errorf("parser has %d error(s)", len(errors))
+	t.Errorf("parser has %d error(s) for %q", len(errors), input)
 	for _, msg := range errors {
 		t.Errorf("parser error: %s", msg)
 	}
@@ -66,7 +66,7 @@ return 993322;
 	p := parser.New(l)
 
 	program := p.ParseProgram()
-	checkParserErrors(t, p)
+	checkParserErrors(t, input, p)
 
 	if len(program.Statements) != 3 {
 		t.Fatalf("program.Statements does not contain 3 statements. got=%d",
@@ -92,7 +92,7 @@ func Test_IdentifierExpression(t *testing.T) {
 	l := lexer.New(input)
 	p := parser.New(l)
 	program := p.ParseProgram()
-	checkParserErrors(t, p)
+	checkParserErrors(t, input, p)
 
 	if len(program.Statements) != 1 {
 		t.Fatalf("program has not enough statements. got=%d",
@@ -134,8 +134,12 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 			"!(-a)", // or maybe !-a - it's more compact but... less readable?
 		},
 		{
-			"--a",
 			"-(-a)",
+			"-(-a)",
+		},
+		{
+			"a--",
+			"a--",
 		},
 		{
 			"a + b + c",
@@ -191,7 +195,7 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 		l := lexer.New(tt.input)
 		p := parser.New(l)
 		program := p.ParseProgram()
-		checkParserErrors(t, p)
+		checkParserErrors(t, tt.input, p)
 
 		actual := ast.DebugString(program)
 		last := actual[len(actual)-1]

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -118,6 +118,10 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 		expected string
 	}{
 		{
+			"a--",
+			"a--",
+		},
+		{
 			"1+2 + 3",
 			"(1 + 2) + 3",
 		},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -118,10 +118,6 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 		expected string
 	}{
 		{
-			"a--",
-			"a--",
-		},
-		{
 			"1+2 + 3",
 			"(1 + 2) + 3",
 		},

--- a/parser/priority_string.go
+++ b/parser/priority_string.go
@@ -15,14 +15,13 @@ func _() {
 	_ = x[SUM-5]
 	_ = x[PRODUCT-6]
 	_ = x[PREFIX-7]
-	_ = x[POSTFIX-8]
-	_ = x[CALL-9]
-	_ = x[INDEX-10]
+	_ = x[CALL-8]
+	_ = x[INDEX-9]
 }
 
-const _Priority_name = "LOWESTASSIGNEQUALSLESSGREATERSUMPRODUCTPREFIXPOSTFIXCALLINDEX"
+const _Priority_name = "LOWESTASSIGNEQUALSLESSGREATERSUMPRODUCTPREFIXCALLINDEX"
 
-var _Priority_index = [...]uint8{0, 6, 12, 18, 29, 32, 39, 45, 52, 56, 61}
+var _Priority_index = [...]uint8{0, 6, 12, 18, 29, 32, 39, 45, 49, 54}
 
 func (i Priority) String() string {
 	i -= 1

--- a/parser/priority_string.go
+++ b/parser/priority_string.go
@@ -15,13 +15,14 @@ func _() {
 	_ = x[SUM-5]
 	_ = x[PRODUCT-6]
 	_ = x[PREFIX-7]
-	_ = x[CALL-8]
-	_ = x[INDEX-9]
+	_ = x[POSTFIX-8]
+	_ = x[CALL-9]
+	_ = x[INDEX-10]
 }
 
-const _Priority_name = "LOWESTASSIGNEQUALSLESSGREATERSUMPRODUCTPREFIXCALLINDEX"
+const _Priority_name = "LOWESTASSIGNEQUALSLESSGREATERSUMPRODUCTPREFIXPOSTFIXCALLINDEX"
 
-var _Priority_index = [...]uint8{0, 6, 12, 18, 29, 32, 39, 45, 49, 54}
+var _Priority_index = [...]uint8{0, 6, 12, 18, 29, 32, 39, 45, 52, 56, 61}
 
 func (i Priority) String() string {
 	i -= 1

--- a/token/token.go
+++ b/token/token.go
@@ -97,6 +97,8 @@ const (
 	GTEQ
 	EQ
 	NOTEQ
+	INCR
+	DECR
 
 	endMultiCharTokens
 
@@ -226,6 +228,8 @@ func Init() {
 	assocS(GTEQ, ">=")
 	assocS(EQ, "==")
 	assocS(NOTEQ, "!=")
+	assocS(INCR, "++")
+	assocS(DECR, "--")
 	// Special alias for := to be same as ASSIGN.
 	sTokens[":="] = cTokens['=']
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -75,6 +75,8 @@ func TestMultiCharTokens(t *testing.T) {
 		{"!=", NOTEQ},
 		{">=", GTEQ},
 		{"<=", LTEQ},
+		{"++", INCR},
+		{"--", DECR},
 	}
 	for _, tt := range tests {
 		tok := &Token{tokenType: tt.expected, literal: tt.input}

--- a/token/type_string.go
+++ b/token/type_string.go
@@ -41,31 +41,33 @@ func _() {
 	_ = x[GTEQ-30]
 	_ = x[EQ-31]
 	_ = x[NOTEQ-32]
-	_ = x[endMultiCharTokens-33]
-	_ = x[startIdentityTokens-34]
-	_ = x[FUNC-35]
-	_ = x[TRUE-36]
-	_ = x[FALSE-37]
-	_ = x[IF-38]
-	_ = x[ELSE-39]
-	_ = x[RETURN-40]
-	_ = x[STRING-41]
-	_ = x[MACRO-42]
-	_ = x[QUOTE-43]
-	_ = x[UNQUOTE-44]
-	_ = x[LEN-45]
-	_ = x[FIRST-46]
-	_ = x[REST-47]
-	_ = x[PRINT-48]
-	_ = x[LOG-49]
-	_ = x[ERROR-50]
-	_ = x[endIdentityTokens-51]
-	_ = x[EOF-52]
+	_ = x[INCR-33]
+	_ = x[DECR-34]
+	_ = x[endMultiCharTokens-35]
+	_ = x[startIdentityTokens-36]
+	_ = x[FUNC-37]
+	_ = x[TRUE-38]
+	_ = x[FALSE-39]
+	_ = x[IF-40]
+	_ = x[ELSE-41]
+	_ = x[RETURN-42]
+	_ = x[STRING-43]
+	_ = x[MACRO-44]
+	_ = x[QUOTE-45]
+	_ = x[UNQUOTE-46]
+	_ = x[LEN-47]
+	_ = x[FIRST-48]
+	_ = x[REST-49]
+	_ = x[PRINT-50]
+	_ = x[LOG-51]
+	_ = x[ERROR-52]
+	_ = x[endIdentityTokens-53]
+	_ = x[EOF-54]
 }
 
-const _Type_name = "ILLEGALEOLstartValueTokensIDENTINTFLOATLINECOMMENTendValueTokensstartSingleCharTokensASSIGNPLUSMINUSBANGASTERISKSLASHPERCENTLTGTCOMMASEMICOLONLPARENRPARENLBRACERBRACELBRACKETRBRACKETCOLONendSingleCharTokensstartMultiCharTokensLTEQGTEQEQNOTEQendMultiCharTokensstartIdentityTokensFUNCTRUEFALSEIFELSERETURNSTRINGMACROQUOTEUNQUOTELENFIRSTRESTPRINTLOGERRORendIdentityTokensEOF"
+const _Type_name = "ILLEGALEOLstartValueTokensIDENTINTFLOATLINECOMMENTendValueTokensstartSingleCharTokensASSIGNPLUSMINUSBANGASTERISKSLASHPERCENTLTGTCOMMASEMICOLONLPARENRPARENLBRACERBRACELBRACKETRBRACKETCOLONendSingleCharTokensstartMultiCharTokensLTEQGTEQEQNOTEQINCRDECRendMultiCharTokensstartIdentityTokensFUNCTRUEFALSEIFELSERETURNSTRINGMACROQUOTEUNQUOTELENFIRSTRESTPRINTLOGERRORendIdentityTokensEOF"
 
-var _Type_index = [...]uint16{0, 7, 10, 26, 31, 34, 39, 50, 64, 85, 91, 95, 100, 104, 112, 117, 124, 126, 128, 133, 142, 148, 154, 160, 166, 174, 182, 187, 206, 226, 230, 234, 236, 241, 259, 278, 282, 286, 291, 293, 297, 303, 309, 314, 319, 326, 329, 334, 338, 343, 346, 351, 368, 371}
+var _Type_index = [...]uint16{0, 7, 10, 26, 31, 34, 39, 50, 64, 85, 91, 95, 100, 104, 112, 117, 124, 126, 128, 133, 142, 148, 154, 160, 166, 174, 182, 187, 206, 226, 230, 234, 236, 241, 245, 249, 267, 286, 290, 294, 299, 301, 305, 311, 317, 322, 327, 334, 337, 342, 346, 351, 354, 359, 376, 379}
 
 func (i Type) String() string {
 	if i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
- Adding postfix expressions (++ and --)  Fixes #17 
- changed evaluation order to be more human friendly (appears left to right now)
- remove extra () if the expression is:   `ident = expre` e.g `a = 1 + 2` instead of `a = (1 + 2)` before

