### PR TITLE
New simpler api for grol New(), Parse(input), Run(io.Writer); switch lex'ing lookup of 2 char to [2]byte from string

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Lexer struct {
-	input         string
+	input         []byte
 	pos           int
 	lineMode      bool
 	hadWhitespace bool
@@ -15,11 +15,15 @@ type Lexer struct {
 
 // Mode with input expected the be complete (multiline/file).
 func New(input string) *Lexer {
-	return &Lexer{input: input}
+	return NewBytes([]byte(input))
 }
 
 func NewLineMode(input string) *Lexer {
-	return &Lexer{input: input, lineMode: true}
+	return &Lexer{input: []byte(input), lineMode: true}
+}
+
+func NewBytes(input []byte) *Lexer {
+	return &Lexer{input: input}
 }
 
 func (l *Lexer) NextToken() *token.Token {
@@ -138,7 +142,7 @@ func (l *Lexer) readIdentifier() string {
 	for isAlphaNum(l.peekChar()) {
 		l.pos++
 	}
-	return l.input[pos:l.pos]
+	return string(l.input[pos:l.pos])
 }
 
 func notEOL(ch byte) bool {
@@ -150,7 +154,7 @@ func (l *Lexer) readLineComment() string {
 	for notEOL(l.peekChar()) {
 		l.pos++
 	}
-	return l.input[pos:l.pos]
+	return string(l.input[pos:l.pos])
 }
 
 func (l *Lexer) readNumber(ch byte) (token.Type, string) {
@@ -170,7 +174,7 @@ func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 			l.pos++
 		}
 	}
-	return t, l.input[pos:l.pos]
+	return t, string(l.input[pos:l.pos])
 }
 
 func isLetter(ch byte) bool {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -22,6 +22,7 @@ func NewLineMode(input string) *Lexer {
 	return &Lexer{input: []byte(input), lineMode: true}
 }
 
+// Bytes based full input mode.
 func NewBytes(input []byte) *Lexer {
 	return &Lexer{input: input}
 }
@@ -33,17 +34,15 @@ func (l *Lexer) NextToken() *token.Token {
 	case '=', '!', ':':
 		if l.peekChar() == '=' {
 			nextChar := l.readChar()
-			literal := string(ch) + string(nextChar)
 			// := is aliased directly to ASSIGN (with = as literal), a bit hacky but
 			// so we normalize := like it didn't exist.
-			return token.ConstantTokenStr(literal)
+			return token.ConstantTokenChar2(ch, nextChar)
 		}
 		return token.ConstantTokenChar(ch)
 	case '+', '-':
 		if l.peekChar() == ch {
 			nextChar := l.readChar()
-			literal := string(ch) + string(nextChar) // TODO: consider making a ContantTokenChar2 instead of making a string
-			return token.ConstantTokenStr(literal)   // increment/decrement
+			return token.ConstantTokenChar2(ch, nextChar) // increment/decrement
 		}
 		return token.ConstantTokenChar(ch)
 	case '%', '*', ';', ',', '{', '}', '(', ')', '[', ']':
@@ -57,8 +56,7 @@ func (l *Lexer) NextToken() *token.Token {
 	case '<', '>':
 		if l.peekChar() == '=' {
 			nextChar := l.readChar()
-			literal := string(ch) + string(nextChar)
-			return token.ConstantTokenStr(literal)
+			return token.ConstantTokenChar2(ch, nextChar)
 		}
 		return token.ConstantTokenChar(ch)
 	case '"':

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -179,7 +179,7 @@ j--
 }
 
 func TestNextTokenEOLMode(t *testing.T) {
-	input := `if .5 {`
+	input := `if .5 { x ( `
 	l := NewLineMode(input)
 	tests := []struct {
 		expectedType    token.Type
@@ -188,6 +188,8 @@ func TestNextTokenEOLMode(t *testing.T) {
 		{token.IF, "if"},
 		{token.FLOAT, ".5"},
 		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.LPAREN, "("},
 		{token.EOL, ""},
 	}
 	for i, tt := range tests {
@@ -201,6 +203,15 @@ func TestNextTokenEOLMode(t *testing.T) {
 		if tok.Literal() != tt.expectedLiteral {
 			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%v",
 				i, tt.expectedLiteral, tok)
+		}
+		if i == 0 {
+			if l.HadWhitespace() {
+				t.Errorf("tests[%d] - didn't expected on first", i)
+			}
+		} else {
+			if !l.HadWhitespace() {
+				t.Errorf("tests[%d] - expected whitespace", i)
+			}
 		}
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -41,7 +41,6 @@ i++
 j--
 @
 `
-
 	tests := []struct {
 		expectedType    token.Type
 		expectedLiteral string
@@ -164,6 +163,7 @@ j--
 	l := New(input)
 
 	for i, tt := range tests {
+		t.Logf("test %d: %v", i, tt)
 		tok := l.NextToken()
 
 		if tok.Type() != tt.expectedType {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -109,8 +109,8 @@ func New() *Grol {
 	return g
 }
 
-func (g *Grol) Parse(what string) error {
-	l := lexer.New(what)
+func (g *Grol) Parse(inp []byte) error {
+	l := lexer.NewBytes(inp)
 	p := parser.New(l)
 	g.program = p.ParseProgram()
 	if len(p.Errors()) > 0 {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -84,7 +84,7 @@ func TestMultiCharTokens(t *testing.T) {
 		if tok == tok2 {
 			t.Errorf("Intern[%s] was unexpectedly created", tt.input)
 		}
-		tok3 := ConstantTokenStr(tt.input)
+		tok3 := ConstantTokenChar2(tt.input[0], tt.input[1])
 		if tok3 != tok2 {
 			t.Errorf("ConstantTokenStr[%s] was not found", tt.input)
 		}
@@ -127,7 +127,7 @@ func TestSingleCharTokens(t *testing.T) {
 func TestColonEqualAlias(t *testing.T) {
 	Init()
 	// Test := alias
-	tok := ConstantTokenStr(":=")
+	tok := ConstantTokenChar2(':', '=')
 	if tok == nil {
 		t.Fatalf("ConstantTokenStr[:=] was not found")
 	}


### PR DESCRIPTION
Also for #31 
See https://github.com/grol-io/scriggo-bench

Also did address/implement the // TODO: consider making a ContantTokenChar2 instead of making a string