### PR TITLE
new -compact mode, also use for eval when printing function objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [Open Issues](https://grol.io/grol/issues) for what's left to do
 ### CLI Usage
 
 ```
-grol 0.25.0 usage:
+grol 0.29.0 usage:
 	grol [flags] *.gr files to interpret or `-` for stdin without prompt
   or no arguments for stdin repl...
 or 1 of the special arguments
@@ -151,6 +151,8 @@ or 1 of the special arguments
 flags:
   -c string
     	command/inline script to run instead of interactive mode
+  -compact
+    	When printing code, use no indentation and most compact form
   -eval
     	show eval results (default true)
   -format

--- a/check_samples_double_format.sh
+++ b/check_samples_double_format.sh
@@ -8,5 +8,10 @@ for file in "$@"; do
     ./grol $file > /tmp/output1
     ./grol /tmp/format2 > /tmp/output2
     diff -u /tmp/output1 /tmp/output2
+    ./grol -format -compact $file > /tmp/format3
+    ./grol -format -compact /tmp/format3 > /tmp/format4
+    diff -u /tmp/format3 /tmp/format4
+    ./grol /tmp/format4 > /tmp/output3
+    diff -u /tmp/output1 /tmp/output3
     echo "---done---"
 done

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func Main() int {
 	commandFlag := flag.String("c", "", "command/inline script to run instead of interactive mode")
 	showParse := flag.Bool("parse", false, "show parse tree")
 	format := flag.Bool("format", false, "don't execute, just parse and re format the input")
+	compact := flag.Bool("compact", false, "When printing code, use no indentation and most compact form")
 	showEval := flag.Bool("eval", true, "show eval results")
 	sharedState := flag.Bool("shared-state", false, "All files share same interpreter state (default is new state for each)")
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
@@ -30,6 +31,7 @@ func Main() int {
 		ShowParse:  *showParse,
 		ShowEval:   *showEval,
 		FormatOnly: *format,
+		Compact:    *compact,
 	}
 	nArgs := len(flag.Args())
 	if *commandFlag != "" {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,11 @@ func Main() int {
 
 func processOneFile(file string, s, macroState *eval.State, options repl.Options) {
 	if file == "-" {
-		log.Infof("Running on stdin")
+		if options.FormatOnly {
+			log.Infof("Formatting stdin")
+		} else {
+			log.Infof("Running on stdin")
+		}
 		repl.EvalAll(s, macroState, os.Stdin, os.Stdout, options)
 		return
 	}
@@ -70,7 +74,11 @@ func processOneFile(file string, s, macroState *eval.State, options repl.Options
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	log.Infof("Running %s", file)
+	verb := "Running"
+	if options.FormatOnly {
+		verb = "Formatting"
+	}
+	log.Infof("%s %s", verb, file)
 	repl.EvalAll(s, macroState, f, os.Stdout, options)
 	f.Close()
 }

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -88,6 +88,6 @@ first(m["key"]) // get the value from key from map, which is an array, and the f
 
 -- sample_test_stdout.gr --
 macro test: greater
-m is: {73:29, "key":[120, "abc", 73]} .
+m is: {73:29,"key":[120,"abc",73]} .
 Outputting a smiley: 😀
 120

--- a/object/object.go
+++ b/object/object.go
@@ -192,7 +192,7 @@ func (f Function) Inspect() string {
 	out.WriteString("func")
 	out.WriteString("(")
 	ps := &ast.PrintState{Out: &out, Compact: true}
-	ast.PrintList(ps, f.Parameters, ", ")
+	ps.ComaList(f.Parameters)
 	out.WriteString("){")
 	f.Body.PrettyPrint(ps)
 	out.WriteString("}")
@@ -305,9 +305,10 @@ func (m Macro) Type() Type { return MACRO }
 func (m Macro) Inspect() string {
 	out := strings.Builder{}
 	out.WriteString("macro(")
-	ast.PrintList(&ast.PrintState{Out: &out}, m.Parameters, ", ")
-	out.WriteString("){\n")
-	m.Body.PrettyPrint(&ast.PrintState{Out: &out})
-	out.WriteString("\n}")
+	ps := &ast.PrintState{Out: &out, Compact: true}
+	ps.ComaList(m.Parameters)
+	out.WriteString("){")
+	m.Body.PrettyPrint(ps)
+	out.WriteString("}")
 	return out.String()
 }

--- a/object/object.go
+++ b/object/object.go
@@ -191,9 +191,11 @@ func (f Function) Inspect() string {
 
 	out.WriteString("func")
 	out.WriteString("(")
-	ast.PrintList(&ast.PrintState{Out: &out}, f.Parameters, ", ")
-	out.WriteString(") ")
-	f.Body.PrettyPrint(&ast.PrintState{Out: &out})
+	ps := &ast.PrintState{Out: &out, Compact: true}
+	ast.PrintList(ps, f.Parameters, ", ")
+	out.WriteString("){")
+	f.Body.PrettyPrint(ps)
+	out.WriteString("}")
 	return out.String()
 }
 
@@ -204,7 +206,7 @@ type Array struct {
 func (ao Array) Type() Type { return ARRAY }
 func (ao Array) Inspect() string {
 	out := strings.Builder{}
-	WriteStrings(&out, ao.Elements, "[", ", ", "]")
+	WriteStrings(&out, ao.Elements, "[", ",", "]")
 	return out.String()
 }
 
@@ -269,7 +271,7 @@ func (m Map) Inspect() string {
 	sort.Sort(keys)
 	for i, k := range keys {
 		if i != 0 {
-			out.WriteString(", ")
+			out.WriteString(",")
 		}
 		v := m[k]
 		out.WriteString(k.Inspect())
@@ -304,7 +306,7 @@ func (m Macro) Inspect() string {
 	out := strings.Builder{}
 	out.WriteString("macro(")
 	ast.PrintList(&ast.PrintState{Out: &out}, m.Parameters, ", ")
-	out.WriteString(") {\n")
+	out.WriteString("){\n")
 	m.Body.PrettyPrint(&ast.PrintState{Out: &out})
 	out.WriteString("\n}")
 	return out.String()

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -38,6 +38,7 @@ type Options struct {
 	All        bool
 	NoColor    bool // color controlled by log package, unless this is set to true.
 	FormatOnly bool
+	Compact    bool
 }
 
 func EvalAll(s, macroState *eval.State, in io.Reader, out io.Writer, options Options) {
@@ -160,14 +161,18 @@ func EvalOne(s, macroState *eval.State, what string, out io.Writer, options Opti
 	if p.ContinuationNeeded() {
 		return true, nil, what
 	}
-	formatted := program.PrettyPrint(ast.NewPrintState()).String()
+	printer := ast.NewPrintState()
+	printer.Compact = options.Compact
+	formatted := program.PrettyPrint(printer).String()
 	if options.FormatOnly {
 		_, _ = out.Write([]byte(formatted))
 		return false, nil, formatted
 	}
 	if options.ShowParse {
-		fmt.Fprint(out, "== Parse ==> ")
-		program.PrettyPrint(&ast.PrintState{Out: out})
+		fmt.Fprint(out, "== Parse ==> ", formatted)
+		if options.Compact {
+			fmt.Fprintln(out)
+		}
 	}
 	macroState.DefineMacros(program)
 	numMacros := macroState.Len()


### PR DESCRIPTION
```
$ ./grol -format -compact examples/sample.gr  2> /dev/null; echo
unless=macro(cond,iffalse,iftrue){quote(if !unquote(cond){unquote(iffalse)}else{unquote(iftrue)})}unless(10>5,print("BUG: not greater\n"),print("macro test: greater\n"))fact=func(n){log("called fact ",n)if n<=1{return 1}n*self(n-1)}a=[fact(5),"abc",76-3]m={"key":a,73:29}print("m is:",m,"\n")print("Outputting a smiley: 😀\n")first((m["key"]))
```

```
$ ./grol -format -compact examples/sample.gr | ./grol -format -
12:50:10.965 grol dev  go1.22.5 arm64 darwin - welcome!
12:50:10.965 grol dev  go1.22.5 arm64 darwin - welcome!
12:50:10.966 [INF] Formatting stdin
12:50:10.966 [INF] Formatting examples/sample.gr
12:50:10.966 [INF] All done
unless = macro(cond, iffalse, iftrue) {
	quote(if !unquote(cond) {
		unquote(iffalse)
	} else {
		unquote(iftrue)
	})
}
unless(10 > 5, print("BUG: not greater\n"), print("macro test: greater\n"))
fact = func(n) {
	log("called fact ", n)
	if n <= 1 {
		return 1
	}
	n * self(n - 1)
}
a = [fact(5), "abc", 76 - 3]
m = {"key":a, 73:29}
print("m is:", m, "\n")
print("Outputting a smiley: 😀\n")
first((m["key"]))
12:50:10.967 [INF] All done
```

relates a bit to #38