### PR TITLE
Auto memoization, "Share" button on wasm/online

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ print, log
 
 macros and more all the time (like canonical reformat using `grol -format` and wasm/online version etc)
 
+automatic memoization
+
 See also [sample.gr](examples/sample.gr) and others in that folder, that you can run with
 ```
 gorepl examples/*.gr

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -24,6 +24,10 @@ func NewState() *State {
 	return &State{env: object.NewEnvironment(), Out: os.Stdout, cache: NewCache()}
 }
 
+func (s *State) ResetCache() {
+	s.cache = NewCache()
+}
+
 // Forward to env to count the number of bindings. Used mostly to know if there are any macros.
 func (s *State) Len() int {
 	return s.env.Len()

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -14,14 +15,15 @@ import (
 )
 
 type State struct {
-	env   *object.Environment
-	Out   io.Writer
-	NoLog bool // turn log() into print() (for EvalString)
-	cache Cache
+	env    *object.Environment
+	Out    io.Writer
+	LogOut io.Writer
+	NoLog  bool // turn log() into print() (for EvalString)
+	cache  Cache
 }
 
 func NewState() *State {
-	return &State{env: object.NewEnvironment(), Out: os.Stdout, cache: NewCache()}
+	return &State{env: object.NewEnvironment(), Out: os.Stdout, LogOut: os.Stdout, cache: NewCache()}
 }
 
 func (s *State) ResetCache() {
@@ -250,14 +252,17 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 		}
 		doLog := node.Type() != token.PRINT
 		if s.NoLog && doLog {
-			doLog = false
 			buf.WriteRune('\n') // log() has a implicit newline when using log.Xxx, print() doesn't.
 		}
-		if doLog {
+		if doLog && !s.NoLog {
 			// Consider passing the arguments to log instead of making a string concatenation.
 			log.Printf("%s", buf.String())
 		} else {
-			_, err := s.Out.Write([]byte(buf.String()))
+			where := s.Out
+			if doLog {
+				where = s.LogOut
+			}
+			_, err := where.Write([]byte(buf.String()))
 			if err != nil {
 				log.Warnf("print: %v", err)
 			}
@@ -330,8 +335,9 @@ func (s *State) applyFunction(name string, fn object.Object, args []object.Objec
 	if !ok {
 		return object.Error{Value: "<not a function: " + fn.Type().String() + ":" + fn.Inspect() + ">"}
 	}
-	if v, ok := s.cache.Get(function.CacheKey, args); ok {
+	if v, output, ok := s.cache.Get(function.CacheKey, args); ok {
 		log.Debugf("Cache hit for %s %v", function.CacheKey, args)
+		_, _ = s.Out.Write(output)
 		return v
 	}
 	nenv, oerr := extendFunctionEnv(name, function, args)
@@ -340,10 +346,16 @@ func (s *State) applyFunction(name string, fn object.Object, args []object.Objec
 	}
 	curState := s.env
 	s.env = nenv
+	oldOut := s.Out
+	buf := bytes.Buffer{}
+	s.Out = &buf
 	res := s.Eval(function.Body) // Need to have the return value unwrapped. Fixes bug #46
 	// restore the previous env/state.
 	s.env = curState
-	s.cache.Set(function.CacheKey, args, res)
+	s.Out = oldOut
+	output := buf.Bytes()
+	_, _ = s.Out.Write(output)
+	s.cache.Set(function.CacheKey, args, res, output)
 	log.Debugf("Cache miss for %s %v", function.CacheKey, args)
 	return res
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -15,6 +15,7 @@ func TestEvalIntegerExpression(t *testing.T) {
 		input    string
 		expected int64
 	}{
+		{`f=func(x) {len(x)}; f([1,2,3])`, 3},
 		{"(3)\n(4)", 4}, // expression on new line should be... new.
 		{"5 // is 5", 5},
 		{"10", 10},
@@ -56,7 +57,6 @@ func(n) {
 }(5)
 `, 120},
 	}
-
 	for i, tt := range tests {
 		evaluated := testEval(t, tt.input)
 		r := testIntegerObject(t, evaluated, tt.expected)

--- a/eval/memo.go
+++ b/eval/memo.go
@@ -1,0 +1,43 @@
+package eval
+
+import (
+	"grol.io/grol/object"
+)
+
+const MaxArgs = 6
+
+type CacheKey struct {
+	Fn   string
+	Args [MaxArgs]object.Object
+}
+
+type Cache map[CacheKey]object.Object
+
+func NewCache() Cache {
+	return make(Cache)
+}
+
+func (c Cache) Get(fn string, args []object.Object) (object.Object, bool) {
+	key := CacheKey{Fn: fn}
+	for i, v := range args {
+		// Can't hash functions arguments (yet).
+		if _, ok := v.(object.Function); ok {
+			return nil, false
+		}
+		key.Args[i] = v
+	}
+	result, ok := c[key]
+	return result, ok
+}
+
+func (c Cache) Set(fn string, args []object.Object, result object.Object) {
+	key := CacheKey{Fn: fn}
+	for i, v := range args {
+		// Can't hash functions arguments (yet).
+		if _, ok := v.(object.Function); ok {
+			return
+		}
+		key.Args[i] = v
+	}
+	c[key] = result
+}

--- a/eval/memo.go
+++ b/eval/memo.go
@@ -23,8 +23,8 @@ func (c Cache) Get(fn string, args []object.Object) (object.Object, bool) {
 	}
 	key := CacheKey{Fn: fn}
 	for i, v := range args {
-		// Can't hash functions arguments (yet).
-		if _, ok := v.(object.Function); ok {
+		// Can't hash functions, arrays, maps arguments (yet).
+		if !object.Hashable(v) {
 			return nil, false
 		}
 		key.Args[i] = v
@@ -40,7 +40,7 @@ func (c Cache) Set(fn string, args []object.Object, result object.Object) {
 	key := CacheKey{Fn: fn}
 	for i, v := range args {
 		// Can't hash functions arguments (yet).
-		if _, ok := v.(object.Function); ok {
+		if !object.Hashable(v) {
 			return
 		}
 		key.Args[i] = v

--- a/eval/memo.go
+++ b/eval/memo.go
@@ -11,29 +11,34 @@ type CacheKey struct {
 	Args [MaxArgs]object.Object
 }
 
-type Cache map[CacheKey]object.Object
+type CacheValue struct {
+	Result object.Object
+	Output []byte
+}
+
+type Cache map[CacheKey]CacheValue
 
 func NewCache() Cache {
 	return make(Cache)
 }
 
-func (c Cache) Get(fn string, args []object.Object) (object.Object, bool) {
+func (c Cache) Get(fn string, args []object.Object) (object.Object, []byte, bool) {
 	if len(args) > MaxArgs {
-		return nil, false
+		return nil, nil, false
 	}
 	key := CacheKey{Fn: fn}
 	for i, v := range args {
 		// Can't hash functions, arrays, maps arguments (yet).
 		if !object.Hashable(v) {
-			return nil, false
+			return nil, nil, false
 		}
 		key.Args[i] = v
 	}
 	result, ok := c[key]
-	return result, ok
+	return result.Result, result.Output, ok
 }
 
-func (c Cache) Set(fn string, args []object.Object, result object.Object) {
+func (c Cache) Set(fn string, args []object.Object, result object.Object, output []byte) {
 	if len(args) > MaxArgs {
 		return
 	}
@@ -45,5 +50,5 @@ func (c Cache) Set(fn string, args []object.Object, result object.Object) {
 		}
 		key.Args[i] = v
 	}
-	c[key] = result
+	c[key] = CacheValue{Result: result, Output: output}
 }

--- a/eval/memo.go
+++ b/eval/memo.go
@@ -4,7 +4,7 @@ import (
 	"grol.io/grol/object"
 )
 
-const MaxArgs = 6
+const MaxArgs = 4
 
 type CacheKey struct {
 	Fn   string
@@ -18,6 +18,9 @@ func NewCache() Cache {
 }
 
 func (c Cache) Get(fn string, args []object.Object) (object.Object, bool) {
+	if len(args) > MaxArgs {
+		return nil, false
+	}
 	key := CacheKey{Fn: fn}
 	for i, v := range args {
 		// Can't hash functions arguments (yet).
@@ -31,6 +34,9 @@ func (c Cache) Get(fn string, args []object.Object) (object.Object, bool) {
 }
 
 func (c Cache) Set(fn string, args []object.Object, result object.Object) {
+	if len(args) > MaxArgs {
+		return
+	}
 	key := CacheKey{Fn: fn}
 	for i, v := range args {
 		// Can't hash functions arguments (yet).

--- a/examples/fib.gr
+++ b/examples/fib.gr
@@ -1,0 +1,10 @@
+fib = func(x) {
+	if x <= 0 {
+		return 0
+	}
+	if x == 1 {
+		return 1
+	}
+	fib(x-1) + fib(x-2)
+}
+fib(50)

--- a/examples/fib.gr
+++ b/examples/fib.gr
@@ -7,4 +7,6 @@ fib = func(x) {
 	}
 	fib(x-1) + fib(x-2)
 }
-fib(50)
+r = fib(50)
+log("fib(50) =", r)
+r

--- a/examples/fib.gr
+++ b/examples/fib.gr
@@ -5,8 +5,8 @@ fib = func(x) {
 	if x == 1 {
 		return 1
 	}
-	fib(x-1) + fib(x-2)
+	fib(x - 1) + fib(x - 2)
 }
-r = fib(50)
-log("fib(50) =", r)
+r = fib(35)
+log("fib(35) =", r)
 r

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -31,10 +31,17 @@ stdout '<err: <identifier not found: foo>>'
 # sample_test.gr
 grol sample_test.gr
 !stderr 'Errors'
-cmp stdout sample_test_stdout.gr
+cmp stdout sample_test_stdout
 stderr 'I] Running sample_test.gr'
 stderr 'called fact 5'
 stderr 'called fact 1'
+stderr 'I] All done'
+
+# fib_50.gr
+grol fib_50.gr
+!stderr 'Errors'
+cmp stdout fib50_stdout
+stderr 'I] Running fib_50.gr'
 stderr 'I] All done'
 
 # Bug repro, return aborts the whole program
@@ -86,8 +93,21 @@ first(m["key"]) // get the value from key from map, which is an array, and the f
 
 // ^^^ gorepl sample.gr should output 120
 
--- sample_test_stdout.gr --
+-- fib_50.gr --
+fib = func(x) {
+	if (x == 0) {
+		return 0
+	}
+	if (x == 1) {
+		return 1
+	}
+	fib(x - 1) + fib(x - 2)
+}
+fib(50)
+-- sample_test_stdout --
 macro test: greater
 m is: {73:29,"key":[120,"abc",73]} .
 Outputting a smiley: 😀
 120
+-- fib50_stdout --
+12586269025

--- a/object/object.go
+++ b/object/object.go
@@ -189,7 +189,7 @@ func WriteStrings(out *strings.Builder, list []Object, before, sep, after string
 func (f Function) Type() Type { return FUNC }
 
 // Must be called after the function is fully initialized.
-func (f Function) SetCacheKey() string {
+func (f *Function) SetCacheKey() string {
 	out := strings.Builder{}
 	out.WriteString("func")
 	out.WriteString("(")
@@ -203,7 +203,7 @@ func (f Function) SetCacheKey() string {
 }
 
 func (f Function) Inspect() string {
-	if f.CacheKey != "" {
+	if f.CacheKey == "" {
 		panic("CacheKey not set")
 	}
 	return f.CacheKey

--- a/object/object.go
+++ b/object/object.go
@@ -48,6 +48,15 @@ type Number interface {
 }
 */
 
+func Hashable(o Object) bool {
+	switch o.Type() { //nolint:exhaustive // We have all the types that are hashable + default for the others.
+	case INTEGER, FLOAT, BOOLEAN, NIL, ERROR, RETURN, QUOTE, STRING:
+		return true
+	default:
+		return false
+	}
+}
+
 func NativeBoolToBooleanObject(input bool) Boolean {
 	if input {
 		return TRUE

--- a/object/object.go
+++ b/object/object.go
@@ -170,6 +170,7 @@ func (rv ReturnValue) Inspect() string { return rv.Value.Inspect() }
 
 type Function struct {
 	Parameters []ast.Node
+	CacheKey   string
 	Body       *ast.Statements
 	Env        *Environment
 }
@@ -186,9 +187,10 @@ func WriteStrings(out *strings.Builder, list []Object, before, sep, after string
 }
 
 func (f Function) Type() Type { return FUNC }
-func (f Function) Inspect() string {
-	out := strings.Builder{}
 
+// Must be called after the function is fully initialized.
+func (f Function) SetCacheKey() string {
+	out := strings.Builder{}
 	out.WriteString("func")
 	out.WriteString("(")
 	ps := &ast.PrintState{Out: &out, Compact: true}
@@ -196,7 +198,15 @@ func (f Function) Inspect() string {
 	out.WriteString("){")
 	f.Body.PrettyPrint(ps)
 	out.WriteString("}")
-	return out.String()
+	f.CacheKey = out.String()
+	return f.CacheKey
+}
+
+func (f Function) Inspect() string {
+	if f.CacheKey != "" {
+		panic("CacheKey not set")
+	}
+	return f.CacheKey
 }
 
 type Array struct {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -68,6 +68,7 @@ func EvalString(what string) (res string, errs []string, formatted string) {
 	macroState := eval.NewState()
 	out := &strings.Builder{}
 	s.Out = out
+	s.LogOut = out
 	s.NoLog = true
 	_, errs, formatted = EvalOne(s, macroState, what, out,
 		Options{All: true, ShowEval: true, NoColor: true, Compact: CompactEvalString})

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -45,15 +45,15 @@ result = fact(5)
 print("Factorial of 5 is", result, ".\n") // print to stdout
 result`
 	expected := `logger fact 3
-print fact 3 .
 logger fact 2
-print fact 2 .
 logger fact 1
+print fact 3 .
+print fact 2 .
 print fact 1 .
 ---
 logger fact 5
-print fact 5 .
 logger fact 4
+print fact 5 .
 print fact 4 .
 print fact 3 .
 print fact 2 .

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -29,6 +29,43 @@ Factorial of 5 is 120` + " \n120\n" // there is an extra space before \n that vs
 	}
 }
 
+func TestEvalMemoPrint(t *testing.T) {
+	s := `
+fact=func(n) {
+	log("logger fact", n) // should be actual executions of the function only
+    print("print fact", n, ".\n") // should get recorded
+    if (n<=1) {
+        return 1
+    }
+    n*self(n-1)
+}
+fact(3)
+print("---\n")
+result = fact(5)
+print("Factorial of 5 is", result, ".\n") // print to stdout
+result`
+	expected := `logger fact 3
+print fact 3 .
+logger fact 2
+print fact 2 .
+logger fact 1
+print fact 1 .
+---
+logger fact 5
+print fact 5 .
+logger fact 4
+print fact 4 .
+print fact 3 .
+print fact 2 .
+print fact 1 .
+Factorial of 5 is 120 .
+120
+`
+	if got, errs, _ := repl.EvalString(s); got != expected || len(errs) > 0 {
+		t.Errorf("EvalString() got %v\n---\n%s\n---want---\n%s\n---", errs, got, expected)
+	}
+}
+
 func TestEvalString50(t *testing.T) {
 	s := `
 fact=func(n) {        // function

--- a/wasm/grol_wasm.html
+++ b/wasm/grol_wasm.html
@@ -119,6 +119,16 @@ m={"str key": a, 42: "str val"}</textarea>
 </div>
 <div>
 Hit enter or click <button onClick="run();" id="runButton" disabled>Run</button> (will also format the code, also try <input type="checkbox" id="compact">compact)
+<button id="addParamButton">Share</button>
+<script>
+    document.getElementById('addParamButton').addEventListener('click', () => {
+        const paramValue = document.getElementById('input').value
+        const url = new URL(window.location)
+        url.searchParams.set('c', paramValue)
+        window.history.pushState({}, '', url)
+    });
+</script>
+
 </div>
 <div>
     <label for="output">Result:</label>
@@ -129,3 +139,11 @@ Hit enter or click <button onClick="run();" id="runButton" disabled>Run</button>
     <textarea id="errors" rows="1" cols="80" class="error-textarea"></textarea>
 </div>
 <div id="version">GROL</div>
+<script>
+    const urlParams = new URLSearchParams(window.location.search)
+    const paramValue = urlParams.get('c')
+    console.log('paramValue', paramValue)
+    if (paramValue) {
+        document.getElementById('input').value = decodeURIComponent(paramValue)
+    }
+</script>


### PR DESCRIPTION
Fixes #72

before
```
BenchmarkGrol/Fibonacci-10.gr-11         	    7478	    155847 ns/op	  130851 B/op	    6502 allocs/op
BenchmarkGrol/Fibonacci-35.gr-11         	       1	26592782750 ns/op	22056347384 B/op	1096181911 allocs/op
```

after
```
BenchmarkGrol/Fibonacci-10.gr-11         	   83880	     14579 ns/op	   13966 B/op	     559 allocs/op
BenchmarkGrol/Fibonacci-35.gr-11         	   24448	     48817 ns/op	   52861 B/op	    1834 allocs/op
```

- [x] handle `print`

We handle print by capturing and saving the output - we exclude log() even in "EvalString" (wasm/discord) mode
so log will show real execution while print will work like expected if there was no memoization

- [x] semi unrelated but added Share button, best used after checking "compact" and run, then share for a short url with the function