### PR TITLE
use loginfo for welcome so -quiet supresses it. check in a test

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func Main() int {
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
 	cli.Main()
-	log.Printf("grol %s - welcome!", cli.LongVersion)
+	log.Infof("grol %s - welcome!", cli.LongVersion)
 	options := repl.Options{
 		ShowParse:  *showParse,
 		ShowEval:   *showEval,
@@ -39,7 +39,7 @@ func Main() int {
 		if len(errs) > 0 {
 			log.Errf("Errors: %v", errs)
 		}
-		fmt.Println(res)
+		fmt.Print(res)
 		return len(errs)
 	}
 	if nArgs == 0 {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -58,6 +58,12 @@ stdout '^1\n3$'
 !grol -c 'm=macro(){};m()'
 stdout '^<err: macro should return Quote. got=object.Null \({}\)>\n$'
 
+# quiet mode and fast fibbonaci
+grol -quiet -c 'fib=func(x){if x<=1 {x} else {fib(x-1)+fib(x-2)}}; fib(92)'
+stdout '^7540113804746346429\n$'
+!stdout '\n\n'
+!stderr .
+
 -- sample_test.gr --
 // Sample file that our gorepl can interpret
 // <--- comments


### PR DESCRIPTION
Also don't println, use print for -c result that already includes a \n