### PR TITLE
Allow else if

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -303,6 +303,23 @@ type IfExpression struct {
 	Alternative *Statements
 }
 
+func (ie IfExpression) handlElse(out *PrintState) {
+	if out.Compact {
+		out.Print("else")
+	} else {
+		out.Print(" else ")
+	}
+	if len(ie.Alternative.Statements) == 1 && ie.Alternative.Statements[0].Value().Type() == token.IF {
+		// else if
+		if out.Compact {
+			out.Print(" ")
+		}
+		ie.Alternative.Statements[0].PrettyPrint(out)
+		return
+	}
+	ie.Alternative.PrettyPrint(out)
+}
+
 func (ie IfExpression) PrettyPrint(out *PrintState) *PrintState {
 	out.Print("if ")
 	ie.Condition.PrettyPrint(out)
@@ -310,14 +327,8 @@ func (ie IfExpression) PrettyPrint(out *PrintState) *PrintState {
 		out.Print(" ")
 	}
 	ie.Consequence.PrettyPrint(out)
-
 	if ie.Alternative != nil {
-		if out.Compact {
-			out.Print("else")
-		} else {
-			out.Print(" else ")
-		}
-		ie.Alternative.PrettyPrint(out)
+		ie.handlElse(out)
 	}
 	return out
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -173,6 +173,9 @@ func TestIfElseExpressions(t *testing.T) {
 		{"if (1 > 2) { 10 }", nil},
 		{"if (1 > 2) { 10 } else { 20 }", 20},
 		{"if (1 < 2) { 10 } else { 20 }", 10},
+		{"i=1; if (i>=3) {10} else if (i>=2) {20} else {30}", 30},
+		{"i=2; if (i>=3) {10} else if (i>=2) {20} else {30}", 20},
+		{"i=3; if (i>=3) {10} else if (i>=2) {20} else {30}", 10},
 	}
 
 	for _, tt := range tests {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -444,6 +444,12 @@ func (p *Parser) parseIfExpression() ast.Node {
 	if p.peekTokenIs(token.ELSE) {
 		p.nextToken()
 
+		if p.peekTokenIs(token.IF) {
+			p.nextToken()
+			expression.Alternative = &ast.Statements{Statements: []ast.Node{p.parseIfExpression()}}
+			return expression
+		}
+
 		if !p.expectPeek(token.LBRACE) {
 			return nil
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -278,6 +278,17 @@ d = [4, 5, 6]
 e = "f"`,
 			`m={1:"a","b":2}c=3 d=[4,5,6]e="f"`,
 		},
+		{
+			`if (i>3) {10} else if (i>2) {20} else {30}`,
+			`if i > 3 {
+	10
+} else if i > 2 {
+	20
+} else {
+	30
+}`,
+			`if i>3{10}else if i>2{20}else{30}`,
+		},
 	}
 	for i, tt := range tests {
 		l := lexer.New(tt.input)
@@ -297,6 +308,8 @@ e = "f"`,
 		if actual != tt.expected {
 			t.Errorf("test [%d] failing for long form\n---input---\n%s\n---expected---\n%s\n---actual---\n%s\n---",
 				i, tt.input, tt.expected, actual)
+			// sometime differences are tabs or newline so print escaped versions too:
+			t.Errorf("test [%d] failing for long form expected %q got %q", i, tt.expected, actual)
 		}
 		ps := ast.NewPrintState()
 		ps.Compact = true


### PR DESCRIPTION
- [x] else if in parsing
- [x] pretty print them specially

```go
if (i>=3) {10} else if (i>=2) {20} else {30}
```

initially parsed and printed as
```go
if i >= 3 {
	10
} else {
	if i >= 2 {
		20
	} else {
		30
	}
}
```
which was correct but ugly, now
```go
if i >= 3 {
	10
} else if i >= 2 {
	20
} else {
	30
}
```
🎉 

fixes #87 