### PR TITLE
implement `func name(...) {....}` as short for `name=func(...) {...}`

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -303,7 +303,7 @@ type IfExpression struct {
 	Alternative *Statements
 }
 
-func (ie IfExpression) handlElse(out *PrintState) {
+func (ie IfExpression) printElse(out *PrintState) {
 	if out.Compact {
 		out.Print("else")
 	} else {
@@ -328,7 +328,7 @@ func (ie IfExpression) PrettyPrint(out *PrintState) *PrintState {
 	}
 	ie.Consequence.PrettyPrint(out)
 	if ie.Alternative != nil {
-		ie.handlElse(out)
+		ie.printElse(out)
 	}
 	return out
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -358,12 +358,17 @@ func (b Builtin) PrettyPrint(out *PrintState) *PrintState {
 
 type FunctionLiteral struct {
 	Base       // The 'func' token
+	Name       *Identifier
 	Parameters []Node
 	Body       *Statements
 }
 
 func (fl FunctionLiteral) PrettyPrint(out *PrintState) *PrintState {
 	out.Print(fl.Literal())
+	if fl.Name != nil {
+		out.Print(" ")
+		out.Print(fl.Name.Literal())
+	}
 	out.Print("(")
 	out.ComaList(fl.Parameters)
 	if out.Compact {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -157,8 +157,12 @@ func (s *State) evalInternal(node any) object.Object {
 	case *ast.FunctionLiteral:
 		params := node.Parameters
 		body := node.Body
-		fn := object.Function{Parameters: params, Env: s.env, Body: body}
+		name := node.Name
+		fn := object.Function{Parameters: params, Name: name, Env: s.env, Body: body}
 		fn.SetCacheKey() // sets cache key
+		if name != nil {
+			s.env.Set(name.Literal(), fn)
+		}
 		return fn
 	case *ast.CallExpression:
 		f := s.evalInternal(node.Function)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -16,6 +16,8 @@ func TestEvalIntegerExpression(t *testing.T) {
 		expected int64
 	}{
 		{`f=func(x) {len(x)}; f([1,2,3])`, 3},
+		// shorthand syntax for function declaration:
+		{`func f(x) {len(x)}; f([1,2,3])`, 3},
 		{"(3)\n(4)", 4}, // expression on new line should be... new.
 		{"5 // is 5", 5},
 		{"10", 10},

--- a/examples/fib.gr
+++ b/examples/fib.gr
@@ -1,11 +1,9 @@
-fib = func(x) {
-	if x <= 0 {
-		return 0
+func fib(x) {
+	if x <= 1 {
+		x
+	} else {
+		fib(x - 1) + fib(x - 2)
 	}
-	if x == 1 {
-		return 1
-	}
-	fib(x - 1) + fib(x - 2)
 }
 r = fib(35)
 log("fib(35) =", r)

--- a/examples/sample.gr
+++ b/examples/sample.gr
@@ -13,7 +13,7 @@ unless = macro(cond, iffalse, iftrue) {
 
 unless(10 > 5, print("BUG: not greater\n"), print("macro test: greater\n"))
 
-fact=func(n) { // function
+fact=func(n) { // first class function objects, can also be written as `func fact(n) {` as shorthand
     log("called fact ", n) // log (timestamped stderr output)
     if (n<=1) {
         return 1

--- a/object/object.go
+++ b/object/object.go
@@ -204,14 +204,19 @@ func (f Function) Type() Type { return FUNC }
 func (f *Function) SetCacheKey() string {
 	out := strings.Builder{}
 	out.WriteString("func")
+	f.printFunc(&out)
+	f.CacheKey = out.String()
+	return f.CacheKey
+}
+
+// Common part of Inspect and SetCacheKey. Prints the rest of the function.
+func (f *Function) printFunc(out *strings.Builder) {
 	out.WriteString("(")
-	ps := &ast.PrintState{Out: &out, Compact: true}
+	ps := &ast.PrintState{Out: out, Compact: true}
 	ps.ComaList(f.Parameters)
 	out.WriteString("){")
 	f.Body.PrettyPrint(ps)
 	out.WriteString("}")
-	f.CacheKey = out.String()
-	return f.CacheKey
 }
 
 func (f Function) Inspect() string {
@@ -221,12 +226,7 @@ func (f Function) Inspect() string {
 	out := strings.Builder{}
 	out.WriteString("func ")
 	out.WriteString(f.Name.Literal())
-	out.WriteString("(")
-	ps := &ast.PrintState{Out: &out, Compact: true}
-	ps.ComaList(f.Parameters)
-	out.WriteString("){")
-	f.Body.PrettyPrint(ps)
-	out.WriteString("}")
+	f.printFunc(&out)
 	return out.String()
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -204,19 +204,19 @@ func (f Function) Type() Type { return FUNC }
 func (f *Function) SetCacheKey() string {
 	out := strings.Builder{}
 	out.WriteString("func")
-	f.printFunc(&out)
-	f.CacheKey = out.String()
+	f.CacheKey = f.finishFuncOutput(&out)
 	return f.CacheKey
 }
 
-// Common part of Inspect and SetCacheKey. Prints the rest of the function.
-func (f *Function) printFunc(out *strings.Builder) {
+// Common part of Inspect and SetCacheKey. Outputs the rest of the function.
+func (f *Function) finishFuncOutput(out *strings.Builder) string {
 	out.WriteString("(")
 	ps := &ast.PrintState{Out: out, Compact: true}
 	ps.ComaList(f.Parameters)
 	out.WriteString("){")
 	f.Body.PrettyPrint(ps)
 	out.WriteString("}")
+	return out.String()
 }
 
 func (f Function) Inspect() string {
@@ -226,8 +226,7 @@ func (f Function) Inspect() string {
 	out := strings.Builder{}
 	out.WriteString("func ")
 	out.WriteString(f.Name.Literal())
-	f.printFunc(&out)
-	return out.String()
+	return f.finishFuncOutput(&out)
 }
 
 type Array struct {

--- a/object/object.go
+++ b/object/object.go
@@ -179,6 +179,7 @@ func (rv ReturnValue) Inspect() string { return rv.Value.Inspect() }
 
 type Function struct {
 	Parameters []ast.Node
+	Name       *ast.Identifier
 	CacheKey   string
 	Body       *ast.Statements
 	Env        *Environment
@@ -198,6 +199,8 @@ func WriteStrings(out *strings.Builder, list []Object, before, sep, after string
 func (f Function) Type() Type { return FUNC }
 
 // Must be called after the function is fully initialized.
+// Whether a function result should be cached doesn't depend on the Name,
+// so it's not part of the cache key.
 func (f *Function) SetCacheKey() string {
 	out := strings.Builder{}
 	out.WriteString("func")
@@ -212,10 +215,19 @@ func (f *Function) SetCacheKey() string {
 }
 
 func (f Function) Inspect() string {
-	if f.CacheKey == "" {
-		panic("CacheKey not set")
+	if f.Name == nil {
+		return f.CacheKey
 	}
-	return f.CacheKey
+	out := strings.Builder{}
+	out.WriteString("func ")
+	out.WriteString(f.Name.Literal())
+	out.WriteString("(")
+	ps := &ast.PrintState{Out: &out, Compact: true}
+	ps.ComaList(f.Parameters)
+	out.WriteString("){")
+	f.Body.PrettyPrint(ps)
+	out.WriteString("}")
+	return out.String()
 }
 
 type Array struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -485,7 +485,13 @@ func (p *Parser) parseBlockStatement() *ast.Statements {
 func (p *Parser) parseFunctionLiteral() ast.Node {
 	lit := &ast.FunctionLiteral{}
 	lit.Token = p.curToken
-
+	// Optional name/identifier
+	if p.peekTokenIs(token.IDENT) {
+		p.nextToken()
+		name := &ast.Identifier{}
+		name.Token = p.curToken
+		lit.Name = name
+	}
 	if !p.expectPeek(token.LPAREN) {
 		return nil
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -289,6 +289,11 @@ e = "f"`,
 }`,
 			`if i>3{10}else if i>2{20}else{30}`,
 		},
+		{
+			`func fact(n) {if (n<=1) {return 1} n*fact(n-1)}`,
+			"func fact(n) {\n\tif n <= 1 {\n\t\treturn 1\n\t}\n\tn * fact(n - 1)\n}",
+			"func fact(n){if n<=1{return 1}n*fact(n-1)}",
+		},
 	}
 	for i, tt := range tests {
 		l := lexer.New(tt.input)

--- a/wasm/grol_wasm.html
+++ b/wasm/grol_wasm.html
@@ -105,7 +105,7 @@
     <label for="input">Edit the sample/Enter your GROL code here:</label>
     <textarea id="input" rows="12" cols="80">
 println("Outputting a smiley: 😀")
-fact=func(n) {    // function example
+func fact(n) {   // function example, name is optional
   log("called fact ", n)  // log output
 // parenthesis are optional:
   if (n<=1) {


### PR DESCRIPTION
- fixes #44 
- also follow up on  if/else PR - typo/bad name `handlElse` -> `printElse` / corrects #91 