### PR TITLE
ALL_CAPS are now constants. Changed/shared recursive function environment. Fixed bug with macro environment. Added pprof.

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -68,7 +68,7 @@ func (s *State) evalAssignment(right object.Object, node *ast.InfixExpression) o
 		return right
 	}
 	log.LogVf("eval assign %#v to %#v", right, id.Value())
-	return s.env.Set(id.Literal(), right)
+	return s.env.Set(id.Literal(), right) // Propagate possible error (constant setting).
 }
 
 func ArgCheck[T any](msg string, n int, vararg bool, args []T) *object.Error {
@@ -104,7 +104,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	case object.Integer:
 		return s.env.Set(id, object.Integer{Value: val.Value + toAdd})
 	case object.Float:
-		return s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)})
+		return s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)}) // So PI++ fails not silently.
 	default:
 		return object.Error{Value: "can't increment/decrement " + val.Type().String()}
 	}
@@ -174,7 +174,7 @@ func (s *State) evalInternal(node any) object.Object {
 		if name != nil {
 			oerr := s.env.Set(name.Literal(), fn)
 			if oerr.Type() == object.ERROR {
-				return oerr
+				return oerr // propagate that func FOO() { ... } can only be defined once.
 			}
 		}
 		return fn

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -116,7 +116,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 }
 
 // Doesn't unwrap return - return bubbles up.
-func (s *State) evalInternal(node any) object.Object {
+func (s *State) evalInternal(node any) object.Object { //nolint:funlen // quite a lot of cases.
 	switch node := node.(type) {
 	// Statements
 	case *ast.Statements:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -447,7 +447,7 @@ func extendFunctionEnv(
 	args []object.Object,
 ) (*object.Environment, *object.Error) {
 	// https://github.com/grol-io/grol/issues/47
-	// fn.Env is "captured state" but for recursion we now parent from current state; eg
+	// fn.Env is "captured state", but for recursion we now parent from current state; eg
 	//     func test(n) {if (n==2) {x=1}; if (n==1) {return x}; test(n-1)}; test(3)
 	// return 1 (state set by recursion with n==2)
 	// Make sure `self` is used to recurse, or named function, otherwise the function will

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -100,14 +100,19 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	default:
 		return object.Error{Value: "unknown postfix operator: " + node.Type().String()}
 	}
+	var oerr object.Object
 	switch val := val.(type) {
 	case object.Integer:
-		return s.env.Set(id, object.Integer{Value: val.Value + toAdd})
+		oerr = s.env.Set(id, object.Integer{Value: val.Value + toAdd})
 	case object.Float:
-		return s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)}) // So PI++ fails not silently.
+		oerr = s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)}) // So PI++ fails not silently.
 	default:
 		return object.Error{Value: "can't increment/decrement " + val.Type().String()}
 	}
+	if oerr.Type() == object.ERROR {
+		return oerr
+	}
+	return val
 }
 
 // Doesn't unwrap return - return bubbles up.

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -68,6 +68,7 @@ func(n) {
 `, 120},
 		{`ONE=1;ONE`, 1},
 		{`ONE=1;ONE=1`, 1}, // Ok to reassign CONSTANT if it's to same value.
+		{`myid=23; func test(n) {if (n==2) {myid=42}; if (n==1) {return myid}; test(n-1)}; test(3)`, 42}, // was 23 before
 	}
 	for i, tt := range tests {
 		evaluated := testEval(t, tt.input)
@@ -241,8 +242,8 @@ func TestErrorHandling(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			`func x(FOO) {log("x",FOO,PI);if FOO<=1 {return FOO}FOO+x(FOO-1)};FOO(1)`,
-			"constant FOO",
+			`func x(FOO) {log("x",FOO,PI);if FOO<=1 {return FOO} x(FOO-1)};x(2)`,
+			"attempt to change constant FOO from 2 to 1",
 		},
 		{
 			`func FOO(x){x}; func FOO(x){x+1}`,

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1,6 +1,7 @@
 package eval_test
 
 import (
+	"os"
 	"testing"
 
 	"grol.io/grol/ast"
@@ -11,7 +12,7 @@ import (
 	"grol.io/grol/parser"
 )
 
-func TestMain(m *testing.M) {	
+func TestMain(m *testing.M) {
 	err := extensions.Init()
 	if err != nil {
 		panic(err)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -11,11 +11,12 @@ import (
 	"grol.io/grol/parser"
 )
 
-func init() {
+func TestMain(m *testing.M) {	
 	err := extensions.Init()
 	if err != nil {
 		panic(err)
 	}
+	os.Exit(m.Run())
 }
 
 func TestEvalIntegerExpression(t *testing.T) {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -232,6 +232,10 @@ func TestErrorHandling(t *testing.T) {
 		expectedMessage string
 	}{
 		{
+			`func x(FOO){log("x",FOO,PI)if FOO<=1{return FOO}FOO+x(FOO-1)};FOO(1)`,
+			"constant FOO",
+		},
+		{
 			"myfunc=func(x,y) {x+y}; myfunc(1)",
 			"wrong number of arguments for myfunc. got=1, want=2",
 		},

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -69,6 +69,10 @@ func(n) {
 		{`ONE=1;ONE`, 1},
 		{`ONE=1;ONE=1`, 1}, // Ok to reassign CONSTANT if it's to same value.
 		{`myid=23; func test(n) {if (n==2) {myid=42}; if (n==1) {return myid}; test(n-1)}; test(3)`, 42}, // was 23 before
+		{
+			`func FACT(n){if n<=1 {return 1}; n*FACT(n-1)};FACT(5)`, // Recursion on CONSTANT function should not error
+			120,
+		},
 	}
 	for i, tt := range tests {
 		evaluated := testEval(t, tt.input)

--- a/eval/macro_expension_test.go
+++ b/eval/macro_expension_test.go
@@ -15,27 +15,26 @@ func TestDefineMacros(t *testing.T) {
     mymacro = macro(x, y) { x + y; }
 	number + 1`
 
-	state := NewState()
-	env := state.env
+	state := object.NewMacroEnvironment()
 	program := testParseProgram(t, input)
 
-	state.DefineMacros(program)
+	DefineMacros(state, program)
 
 	if len(program.Statements) != 3 {
 		t.Fatalf("Wrong number of statements. got=%d: %+v",
 			len(program.Statements), program.Statements)
 	}
 
-	_, ok := env.Get("number")
+	_, ok := state.Get("number")
 	if ok {
 		t.Fatalf("number should not be defined")
 	}
-	_, ok = env.Get("function")
+	_, ok = state.Get("function")
 	if ok {
 		t.Fatalf("function should not be defined")
 	}
 
-	obj, ok := env.Get("mymacro")
+	obj, ok := state.Get("mymacro")
 	if !ok {
 		t.Fatalf("macro not in environment.")
 	}
@@ -124,9 +123,9 @@ func TestExpandMacros(t *testing.T) {
 		expected := testParseProgram(t, tt.expected)
 		program := testParseProgram(t, tt.input)
 
-		state := NewState()
-		state.DefineMacros(program)
-		expanded := state.ExpandMacros(program)
+		state := object.NewMacroEnvironment()
+		DefineMacros(state, program)
+		expanded := ExpandMacros(state, program)
 
 		expandedStr := ast.DebugString(expanded)
 		expectedStr := ast.DebugString(expected)

--- a/examples/pi.gr
+++ b/examples/pi.gr
@@ -1,12 +1,12 @@
-f = func(n, fac, dfac, exp, N) {
+f = func(n, fac, dfac, exp, max) {
   // log("Call n=", n, fac, dfac, exp)
-  if (n>N) {
+  if (n>max) {
     [fac, dfac, exp]
   } else {
     dfac = 1.*dfac*(2*n - 1)
     exp = exp * 2
     fac = fac * n
-    f(n+1, fac, dfac, exp, N)
+    f(n+1, fac, dfac, exp, max)
   }
 }
 N = 100

--- a/examples/pi_perf.gr
+++ b/examples/pi_perf.gr
@@ -1,9 +1,10 @@
-// Somehow this version works fine with grol 0.24, 0.31 but not at all in current - keeping for regression
+// Keep 0.24 syntax for perf comparison. Used to detect a serious performance regression
+// during https://github.com/grol-io/grol/pull/102
 f = func(i, n, prod) {
 	if (i == n+1) {
 		return 1. / (prod * prod * n)
 	}
 	f(i+1, n, prod*(1-1./(2*i)))
 }
-n = 20000
+n = 100000
 f(1, n, 1)

--- a/examples/pi_perf.gr
+++ b/examples/pi_perf.gr
@@ -1,0 +1,9 @@
+// Somehow this version works fine with grol 0.24, 0.31 but not at all in current - keeping for regression
+f = func(i, n, prod) {
+	if (i == n+1) {
+		return 1. / (prod * prod * n)
+	}
+	f(i+1, n, prod*(1-1./(2*i)))
+}
+n = 20000
+f(1, n, 1)

--- a/main.go
+++ b/main.go
@@ -43,11 +43,11 @@ func Main() int {
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
-			log.Fatalf("can't open file for cpu profile: %v", err)
+			return log.FErrf("can't open file for cpu profile: %v", err)
 		}
 		err = pprof.StartCPUProfile(f)
 		if err != nil {
-			log.Fatalf("can't start cpu profile: %v", err)
+			return log.FErrf("can't start cpu profile: %v", err)
 		}
 		log.Infof("Writing cpu profile to %s", *cpuprofile)
 		defer pprof.StopCPUProfile()

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"fortio.org/log"
 	"grol.io/grol/eval"
 	"grol.io/grol/extensions" // register extensions
+	"grol.io/grol/object"
 	"grol.io/grol/repl"
 )
 
@@ -52,19 +53,19 @@ func Main() int {
 	}
 	options.All = true
 	s := eval.NewState()
-	macroState := eval.NewState()
+	macroState := object.NewMacroEnvironment()
 	for _, file := range flag.Args() {
 		processOneFile(file, s, macroState, options)
 		if !*sharedState {
 			s = eval.NewState()
-			macroState = eval.NewState()
+			macroState = object.NewMacroEnvironment()
 		}
 	}
 	log.Infof("All done")
 	return 0
 }
 
-func processOneFile(file string, s, macroState *eval.State, options repl.Options) {
+func processOneFile(file string, s *eval.State, macroState *object.Environment, options repl.Options) {
 	if file == "-" {
 		if options.FormatOnly {
 			log.Infof("Formatting stdin")

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/pprof"
 
 	"fortio.org/cli"
 	"fortio.org/log"
@@ -25,6 +26,9 @@ func Main() int {
 	compact := flag.Bool("compact", false, "When printing code, use no indentation and most compact form")
 	showEval := flag.Bool("eval", true, "show eval results")
 	sharedState := flag.Bool("shared-state", false, "All files share same interpreter state (default is new state for each)")
+	cpuprofile := flag.String("profile-cpu", "", "write cpu profile to `file`")
+	memprofile := flag.String("profile-mem", "", "write memory profile to `file`")
+
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
 	cli.Main()
@@ -35,9 +39,22 @@ func Main() int {
 		FormatOnly: *format,
 		Compact:    *compact,
 	}
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatalf("can't open file for cpu profile: %v", err)
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			log.Fatalf("can't start cpu profile: %v", err)
+		}
+		log.Infof("Writing cpu profile to %s", *cpuprofile)
+		defer pprof.StopCPUProfile()
+	}
 	err := extensions.Init()
 	if err != nil {
-		log.Fatalf("Error initializing extensions: %v", err)
+		return log.FErrf("Error initializing extensions: %v", err)
 	}
 	if *commandFlag != "" {
 		res, errs, _ := repl.EvalString(*commandFlag)
@@ -62,6 +79,18 @@ func Main() int {
 		}
 	}
 	log.Infof("All done")
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			return log.FErrf("can't open file for mem profile: %v", err)
+		}
+		err = pprof.WriteHeapProfile(f)
+		if err != nil {
+			return log.FErrf("can't write mem profile: %v", err)
+		}
+		log.Infof("Wrote memory profile to %s", *memprofile)
+		f.Close()
+	}
 	return 0
 }
 

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -37,7 +37,18 @@ stderr 'called fact 5'
 stderr 'called fact 1'
 stderr 'I] All done'
 
-# fib_50.gr
+# macro output (there is a macro in sample_test.gr, it should show that stage with -parse)
+grol -parse sample_test.gr
+!stderr 'Errors'
+stdout '== Macro ==>'
+
+# no macro stage when no macro in the file:
+grol -parse fib_50.gr
+!stderr 'Errors'
+!stdout '== Macro ==>'
+stdout '12586269025\n'
+
+# fib_50.gr (redoing, checking exact match of output)
 grol fib_50.gr
 !stderr 'Errors'
 cmp stdout fib50_stdout

--- a/object/interp.go
+++ b/object/interp.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"errors"
-	"maps"
 )
 
 var (
@@ -60,7 +59,13 @@ func initialIdentifiersCopy() map[string]Object {
 	if !initDone {
 		Init()
 	}
-	return maps.Clone(extraIdentifiers)
+	// we'd use maps.Clone except for tinygo not having it.
+	// https://github.com/tinygo-org/tinygo/issues/4382
+	copied := make(map[string]Object, len(extraIdentifiers))
+	for k, v := range extraIdentifiers {
+		copied[k] = v
+	}
+	return copied
 }
 
 func Unwrap(objs []Object) []any {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -53,3 +53,24 @@ func TestExtensionUsage(t *testing.T) {
 		t.Errorf("cmd.Inspect() test unlimited args got %q, expected %q", actual, expected)
 	}
 }
+
+func TestIsConstantIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"PI", true},
+		{"FOO_BAR", true},
+		{"_FOO_BAR", false},
+		{"Foo", false},
+		{"E", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := object.IsConstantIdentifier(tt.name)
+			if actual != tt.expected {
+				t.Errorf("object.IsConstantIdentifier(%q) got %v, expected %v", tt.name, actual, tt.expected)
+			}
+		})
+	}
+}

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -67,7 +67,7 @@ func TestIsConstantIdentifier(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := object.IsConstantIdentifier(tt.name)
+			actual := object.Constant(tt.name)
 			if actual != tt.expected {
 				t.Errorf("object.IsConstantIdentifier(%q) got %v, expected %v", tt.name, actual, tt.expected)
 			}

--- a/object/state.go
+++ b/object/state.go
@@ -32,7 +32,9 @@ func (e *Environment) Get(name string) (Object, bool) {
 	return e.outer.Get(name) // recurse.
 }
 
-func IsConstantIdentifier(name string) bool {
+// Defines constant as all CAPS (with _ ok in the middle) identifiers.
+// Note that we use []byte as all identifiers are ASCII.
+func Constant(name string) bool {
 	for i, v := range name {
 		if i != 0 && v == '_' {
 			continue
@@ -45,7 +47,7 @@ func IsConstantIdentifier(name string) bool {
 }
 
 func (e *Environment) Set(name string, val Object) Object {
-	if IsConstantIdentifier(name) {
+	if Constant(name) {
 		old, ok := e.Get(name) // not ok
 		if ok {
 			log.Warnf("Attempt to change constant %s from %v to %v", name, old, val)

--- a/object/state.go
+++ b/object/state.go
@@ -56,7 +56,7 @@ func (e *Environment) Set(name string, val Object) Object {
 	if Constant(name) {
 		old, ok := e.Get(name) // not ok
 		if ok {
-			log.Debugf("Attempt to change constant %s from %v to %v", name, old, val)
+			log.Infof("Attempt to change constant %s from %v to %v", name, old, val)
 			if !Hashable(old) || !Hashable(val) || old != val {
 				return Error{Value: fmt.Sprintf("attempt to change constant %s from %s to %s", name, old.Inspect(), val.Inspect())}
 			}

--- a/wasm/grol_wasm.html
+++ b/wasm/grol_wasm.html
@@ -128,6 +128,7 @@ Hit enter or click <button onClick="run();" id="runButton" disabled>Run</button>
             return str.replace(/\+/g, '%2B')
               .replace(/ /g, '+')
               .replace(/\n/g, '%0A')
+              .replace(/\t/g, '%09')
               .replace(/</g, '%3C')
         }
         const encodedValue = customEscape(paramValue)


### PR DESCRIPTION
fixes #98 

https://github.com/grol-io/grol/issues/47#issuecomment-2267631006

fixes #47

Also fixes mix up with macro environment which was incorrectly reusing the full eval.State when it really only needs object.Environment, split the two. 

This showed up as a bug with ==> macro showing up in output even if no macro was defined (because it got PI and E from other MR)

Added `-profile-mem` and `-profile-cpu` options

Figured out regression and saved as examples/pi_perf.gr

Handle tabs in wasm share button