### PR TITLE
handle exponent notation floats and _s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ grol_tiny.wasm
 wasm/grol_tiny.wasm
 wasm/index.html
 tiny_test
+
+*.svg
+*.prof
+*.pprof

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -29,7 +29,7 @@ func TestEvalIntegerExpression(t *testing.T) {
 		// {"5 + /* block comment in middle of expression */ 2", 7},
 		// {" - /* inline of prefix */ 5", -5},
 		{"2 * 2 * 2 * 2 * 2", 32},
-		{"-50 + 100 + -50", 0},
+		{"-50 + 1_0_0 + -50", 0},
 		{"5 * 2 + 10", 20},
 		{"5 + 2 * 10", 25},
 		{"20 + 2 * -10", 0},

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -199,7 +199,7 @@ func (l *Lexer) readBlockComment() string {
 
 func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 	t := token.INT
-	start := l.pos - 1
+	pos := l.pos - 1
 	dotSeen := false
 	hasDigits := true
 	// Integer part or leading dot for fractional part
@@ -216,7 +216,7 @@ func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 	if l.peekChar() == '.' {
 		if dotSeen {
 			// Stop if we see another dot
-			return t, string(l.input[start : l.pos-1])
+			return t, string(l.input[pos : l.pos-1])
 		}
 		t = token.FLOAT
 		l.pos++
@@ -228,12 +228,12 @@ func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 	// Exponent part
 	peek := l.peekChar()
 	if peek != 'e' && peek != 'E' {
-		return t, string(l.input[start:l.pos])
+		return t, string(l.input[pos:l.pos])
 	}
 	errPos := l.pos
 	if !hasDigits {
 		// Invalid number, stop here if no digits seen before exponent
-		return t, string(l.input[start:errPos])
+		return t, string(l.input[pos:errPos])
 	}
 	l.pos++
 	peek = l.peekChar()
@@ -242,14 +242,14 @@ func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 	}
 	if !isDigit(l.peekChar()) {
 		// Invalid exponent, stop here
-		return t, string(l.input[start:errPos])
+		return t, string(l.input[pos:errPos])
 	}
 	t = token.FLOAT
 	// Read exponent
 	for isDigitOrUnderscore(l.peekChar()) {
 		l.pos++
 	}
-	return t, string(l.input[start:l.pos])
+	return t, string(l.input[pos:l.pos])
 }
 
 func isLetter(ch byte) bool {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -199,7 +199,6 @@ func (l *Lexer) readBlockComment() string {
 
 func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 	t := token.INT
-	pos := l.pos - 1
 	dotSeen := false
 	hasDigits := true
 	// Integer part or leading dot for fractional part
@@ -208,6 +207,7 @@ func (l *Lexer) readNumber(ch byte) (token.Type, string) {
 		hasDigits = false
 		dotSeen = true
 	}
+	pos := l.pos - 1
 	for isDigitOrUnderscore(l.peekChar()) {
 		hasDigits = true
 		l.pos++

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -283,6 +283,9 @@ func TestReadFloatNumber(t *testing.T) {
 		{"100..", "100."},
 		{"1000_000.5", "1000_000.5"},
 		{"1000_000.5_6", "1000_000.5_6"},
+		{"1.23e1_000", "1.23e1_000"},   // too big for float64, but "lexable".
+		{"1.23e+1_000", "1.23e+1_000"}, // too big for float64, but "lexable".
+		{"1.23E-1_000", "1.23E-1_000"}, // too big for float64, but "lexable".
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -256,3 +256,72 @@ func TestNextTokenCommentEOLMode(t *testing.T) {
 		}
 	}
 }
+
+func TestReadFloatNumber(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{".", "."},  // not a valid float number yet we consume and it'll fail to convert later.
+		{".a", "."}, // not a valid float number yet we consume and it'll fail to convert later.
+		{"123.", "123."},
+		{".5", ".5"},
+		{"100.56", "100.56"},
+		{"1e3", "1e3"},
+		{"1.23e-3", "1.23e-3"},
+		{"1.23E+3", "1.23E+3"},
+		{"1e-3", "1e-3"},
+		{"12..3", "12."},
+		{"1e+3", "1e+3"},
+		{"1.23e", "1.23"},
+		{"1.23e+", "1.23"},
+		{"1.23e-", "1.23"},
+		{"1.23e-abc", "1.23"},
+		{"123..", "123."},
+		{"1..23", "1."},
+		{".e3", "."},
+		{"100..", "100."},
+		{"1000_000.5", "1000_000.5"},
+		{"1000_000.5_6", "1000_000.5_6"},
+	}
+
+	for _, tt := range tests {
+		l := New(tt.input)
+		tok := l.NextToken()
+		tokT := tok.Type()
+		result := tok.Literal()
+		isFloat := (tokT == token.FLOAT)
+		if !isFloat {
+			t.Errorf("input: %q, expected a float number, got: %#v", tt.input, tok.DebugString())
+		}
+		if result != tt.expected {
+			t.Errorf("input: %q, expected: %q, got: %q", tt.input, tt.expected, result)
+		}
+	}
+}
+
+func TestReadIntNumber(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1_2_3", "1_2_3"},
+		{"5", "5"},
+		{"100abc", "100"},
+		{"1000_000", "1000_000"},
+	}
+
+	for _, tt := range tests {
+		l := New(tt.input)
+		tok := l.NextToken()
+		tokT := tok.Type()
+		result := tok.Literal()
+		isFloat := (tokT == token.INT)
+		if !isFloat {
+			t.Errorf("input: %q, expected a int number, got: %#v", tt.input, tok.DebugString())
+		}
+		if result != tt.expected {
+			t.Errorf("input: %q, expected: %q, got: %q", tt.input, tt.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
fixes #103 

doesn't complain about multiple consecutive `_` but... the float parser will in eval phase