### PR TITLE
added `info` returning info map. made object.Array sortable replacing MapKeys, use Equals in constant check, fix missing FLOAT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,21 @@ $ m=fact(7)
 $ m/n
 == Parse ==> m / n
 == Eval  ==> 7
-$ info["all_ids"][0]
-["E","PI","abs","log2","printf"]
+$ func fx(n) {if n>0 {return fx(n-1)}; info["all_ids"]}; fx(3)
+== Parse ==> func fx(n) {
+	if n > 0 {
+		return fx(n - 1)
+	}
+	(info["all_ids"])
+}
+fx(3)
+== Eval  ==> {0:["E","PI","abs","fx","log2","printf"],1:["n","self"],2:["fx","n","self"],3:["fx","n","self"],4:["fx","n","self"]}
 $ info["gofuncs"]
-["acos","asin","atan","ceil","cos","exp","floor","ln","log10","pow","round","sin","sprintf","sqrt","tan","trunc"]
+== Parse ==> (info["gofuncs"])
+== Eval  ==> ["acos","asin","atan","ceil","cos","exp","floor","ln","log10","pow","round","sin","sprintf","sqrt","tan","trunc"]
 $ info["keywords"]
-["else","error","false","first","func","if","len","log","macro","print","println","quote","rest","return","true","unquote"]
+== Parse ==> (info["keywords"])
+== Eval  ==> ["else","error","false","first","func","if","len","log","macro","print","println","quote","rest","return","true","unquote"]
 ```
 
 ## Language features

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ easy extensions/adding Go functions to grol (see [extensions/extension.go](exten
 
 variadic functions both Go side and grol side (using `..` on grol side)
 
+Use `info` to see all the available functions, keywords, operators etc... (can be used inside functions too to examine the stack)
+
 See also [sample.gr](examples/sample.gr) and others in that folder, that you can run with
 ```
 gorepl examples/*.gr
@@ -169,4 +171,4 @@ flags:
   -shared-state
     	All files share same interpreter state (default is new state for each)
 ```
-(excluding logger control, see `gorepl help` for all the flags, of note `-logger-no-color` will turn off colors for gorepl too)
+(excluding logger control, see `gorepl help` for all the flags, of note `-logger-no-color` will turn off colors for gorepl too, for development there are also `-profile*` options for pprof)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ $ m=fact(7)
 $ m/n
 == Parse ==> m / n
 == Eval  ==> 7
+$ info["all_ids"][0]
+["E","PI","abs","log2","printf"]
+$ info["gofuncs"]
+["acos","asin","atan","ceil","cos","exp","floor","ln","log10","pow","round","sin","sprintf","sqrt","tan","trunc"]
+$ info["keywords"]
+["else","error","false","first","func","if","len","log","macro","print","println","quote","rest","return","true","unquote"]
 ```
 
 ## Language features

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -645,13 +645,13 @@ func evalArrayInfixExpression(operator token.Type, left, right object.Object) ob
 			return object.FALSE
 		}
 		rightVal := right.(object.Array).Elements
-		return object.ArrayEquals(leftVal, rightVal)
+		return object.NativeBoolToBooleanObject(object.ArrayEquals(leftVal, rightVal))
 	case token.NOTEQ:
 		if right.Type() != object.ARRAY {
 			return object.TRUE
 		}
 		rightVal := right.(object.Array).Elements
-		if object.ArrayEquals(leftVal, rightVal) == object.FALSE {
+		if !object.ArrayEquals(leftVal, rightVal) {
 			return object.TRUE
 		}
 		return object.FALSE
@@ -671,9 +671,9 @@ func evalMapInfixExpression(operator token.Type, left, right object.Object) obje
 	rightMap := right.(object.Map)
 	switch operator { //nolint:exhaustive // we have default.
 	case token.EQ:
-		return object.MapEquals(leftMap, rightMap)
+		return object.NativeBoolToBooleanObject(object.MapEquals(leftMap, rightMap))
 	case token.NOTEQ:
-		if object.MapEquals(leftMap, rightMap) == object.FALSE {
+		if !object.MapEquals(leftMap, rightMap) {
 			return object.TRUE
 		}
 		return object.FALSE

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,13 @@ require (
 
 // replace fortio.org/log => ../../fortio.org/log
 
+require fortio.org/sets v1.1.1
+
 require (
 	fortio.org/struct2env v0.4.1 // indirect
 	github.com/kortschak/goroutine v1.1.2 // indirect
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20240626151235-a6a393ffd658 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/tools v0.8.0 // indirect
+	golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/tools v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+fortio.org/assert v1.2.1 h1:48I39urpeDj65RP1KguF7akCjILNeu6vICiYMEysR7Q=
+fortio.org/assert v1.2.1/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
 fortio.org/cli v1.8.0 h1:Mz1phmUwkQaXESGb1nIWBY+CHli/GYIlhwpktorh9sY=
 fortio.org/cli v1.8.0/go.mod h1:pk/JBE8LcXtNuo5Yj2bLsVbwPaHo8NWdbstSN0cpbFk=
 fortio.org/log v1.16.0 h1:GhU8/9NkYZmEIzvTN/DTMedDAStLJraWUUVUA2EbNDc=
 fortio.org/log v1.16.0/go.mod h1:t58Spg9njjymvRioh5F6qKGSupEsnMjXLGWIS1i3khE=
+fortio.org/sets v1.1.1 h1:Q7Z1Ft2lpUc1N7bfI8HofIK0QskrOflfYRyKT2LzBng=
+fortio.org/sets v1.1.1/go.mod h1:J2BwIxNOLWsSU7IMZUg541kh3Au4JEKHrghVwXs68tE=
 fortio.org/struct2env v0.4.1 h1:rJludAMO5eBvpWplWEQNqoVDFZr4RWMQX7RUapgZyc0=
 fortio.org/struct2env v0.4.1/go.mod h1:lENUe70UwA1zDUCX+8AsO663QCFqYaprk5lnPhjD410=
 fortio.org/testscript v0.3.1 h1:MmRO64AsmzaU1KlYMzAbotJIMKRGxD1XXssJnBRiMGQ=
@@ -14,7 +18,9 @@ github.com/kortschak/goroutine v1.1.2 h1:lhllcCuERxMIK5cYr8yohZZScL1na+JM5JYPRcl
 github.com/kortschak/goroutine v1.1.2/go.mod h1:zKpXs1FWN/6mXasDQzfl7g0LrGFIOiA6cLs9eXKyaMY=
 golang.org/x/crypto/x509roots/fallback v0.0.0-20240626151235-a6a393ffd658 h1:i7K6wQLN/0oxF7FT3tKkfMCstxoT4VGG36YIB9ZKLzI=
 golang.org/x/crypto/x509roots/fallback v0.0.0-20240626151235-a6a393ffd658/go.mod h1:kNa9WdvYnzFwC79zRpLRMJbdEFlhyM5RPFBBZp/wWH8=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
-golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
+golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 h1:LoYXNGAShUG3m/ehNk4iFctuhGX/+R1ZpfJ4/ia80JM=
+golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8/go.mod h1:jj3sYF3dwk5D+ghuXyeI3r5MFf+NT2An6/9dOA95KSI=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=

--- a/object/object.go
+++ b/object/object.go
@@ -74,6 +74,8 @@ func Equals(left, right Object) Object {
 	switch left := left.(type) {
 	case Integer:
 		return NativeBoolToBooleanObject(left.Value == right.(Integer).Value)
+	case Float:
+		return NativeBoolToBooleanObject(left.Value == right.(Float).Value)
 	case String:
 		return NativeBoolToBooleanObject(left.Value == right.(String).Value)
 	case Boolean:
@@ -274,15 +276,13 @@ func NewMap() Map {
 	return make(map[Object]Object)
 }
 
-type MapKeys []Object
-
-func (mk MapKeys) Len() int {
-	return len(mk)
+func (ao Array) Len() int {
+	return len(ao.Elements)
 }
 
-func (mk MapKeys) Less(i, j int) bool {
-	ti := mk[i].Type()
-	tj := mk[j].Type()
+func (ao Array) Less(i, j int) bool {
+	ti := ao.Elements[i].Type()
+	tj := ao.Elements[j].Type()
 	if ti < tj {
 		return true
 	}
@@ -291,18 +291,18 @@ func (mk MapKeys) Less(i, j int) bool {
 	}
 	switch ti { //nolint:exhaustive // We have all the types that exist and can be in a map.
 	case INTEGER:
-		return mk[i].(Integer).Value < mk[j].(Integer).Value
+		return ao.Elements[i].(Integer).Value < ao.Elements[j].(Integer).Value
 	case FLOAT:
-		return mk[i].(Float).Value < mk[j].(Float).Value
+		return ao.Elements[i].(Float).Value < ao.Elements[j].(Float).Value
 	case BOOLEAN:
-		bi := mk[i].(Boolean).Value
-		bj := mk[j].(Boolean).Value
+		bi := ao.Elements[i].(Boolean).Value
+		bj := ao.Elements[j].(Boolean).Value
 		if bi {
 			return false
 		}
 		return bj
 	case STRING:
-		return mk[i].(String).Value < mk[j].(String).Value
+		return ao.Elements[i].(String).Value < ao.Elements[j].(String).Value
 	default:
 		log.Warnf("Unexpected type in map keys: %s", ti)
 		// UNKNOWN, NIL, ERROR, RETURN, FUNC, ARRAY, MAP, QUOTE, MACRO, LAST
@@ -310,8 +310,8 @@ func (mk MapKeys) Less(i, j int) bool {
 	return false
 }
 
-func (mk MapKeys) Swap(i, j int) {
-	mk[i], mk[j] = mk[j], mk[i]
+func (ao Array) Swap(i, j int) {
+	ao.Elements[i], ao.Elements[j] = ao.Elements[j], ao.Elements[i]
 }
 
 func (m Map) Unwrap() any {
@@ -327,13 +327,14 @@ func (m Map) Type() Type { return MAP }
 func (m Map) Inspect() string {
 	out := strings.Builder{}
 	out.WriteString("{")
-	keys := make(MapKeys, 0, len(m))
+	keys := make([]Object, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)
 	}
+	arr := Array{Elements: keys}
 	// Sort the keys
-	sort.Sort(keys)
-	for i, k := range keys {
+	sort.Sort(arr)
+	for i, k := range arr.Elements {
 		if i != 0 {
 			out.WriteString(",")
 		}

--- a/object/object.go
+++ b/object/object.go
@@ -67,52 +67,52 @@ func NativeBoolToBooleanObject(input bool) Boolean {
 	return FALSE
 }
 
-func Equals(left, right Object) Object {
+func Equals(left, right Object) bool {
 	if left.Type() != right.Type() {
-		return FALSE
+		return false
 	}
 	switch left := left.(type) {
 	case Integer:
-		return NativeBoolToBooleanObject(left.Value == right.(Integer).Value)
+		return left.Value == right.(Integer).Value
 	case Float:
-		return NativeBoolToBooleanObject(left.Value == right.(Float).Value)
+		return left.Value == right.(Float).Value
 	case String:
-		return NativeBoolToBooleanObject(left.Value == right.(String).Value)
+		return left.Value == right.(String).Value
 	case Boolean:
-		return NativeBoolToBooleanObject(left.Value == right.(Boolean).Value)
+		return left.Value == right.(Boolean).Value
 	case Null:
-		return TRUE
+		return true
 	case Array:
 		return ArrayEquals(left.Elements, right.(Array).Elements)
 	case Map:
 		return MapEquals(left, right.(Map))
 	default: /*	ERROR RETURN FUNC */
-		return FALSE
+		return false
 	}
 }
 
-func ArrayEquals(left, right []Object) Object {
+func ArrayEquals(left, right []Object) bool {
 	if len(left) != len(right) {
-		return FALSE
+		return false
 	}
 	for i, l := range left {
-		if Equals(l, right[i]) == FALSE {
-			return FALSE
+		if !Equals(l, right[i]) {
+			return false
 		}
 	}
-	return TRUE
+	return true
 }
 
-func MapEquals(left, right Map) Object {
+func MapEquals(left, right Map) bool {
 	if len(left) != len(right) {
-		return FALSE
+		return false
 	}
 	for k, v := range left {
-		if Equals(v, right[k]) == FALSE {
-			return FALSE
+		if !Equals(v, right[k]) {
+			return false
 		}
 	}
-	return TRUE
+	return true
 }
 
 type Integer struct {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -25,7 +25,7 @@ func TestStringMapKey(t *testing.T) {
 	if v != diff1 {
 		t.Errorf("value for key %v is %v, expected %v", hello2, v, diff1)
 	}
-	if object.Equals(diff1, diff2) != object.TRUE {
+	if !object.Equals(diff1, diff2) {
 		t.Errorf("values aren't equal, unexpected")
 	}
 }

--- a/object/state.go
+++ b/object/state.go
@@ -57,7 +57,7 @@ func (e *Environment) BaseInfo() Map {
 	// Ditto cache this as it's set for a given environment.
 	ext := ExtraFunctions()
 	keys = make([]Object, 0, len(ext))
-	for k, _ := range ext {
+	for k := range ext {
 		keys = append(keys, String{Value: k})
 	}
 	arr := Array{Elements: keys}

--- a/object/state.go
+++ b/object/state.go
@@ -124,7 +124,7 @@ func (e *Environment) Set(name string, val Object) Object {
 		old, ok := e.Get(name) // not ok
 		if ok {
 			log.Infof("Attempt to change constant %s from %v to %v", name, old, val)
-			if Equals(old, val) == FALSE {
+			if !Equals(old, val) {
 				return Error{Value: fmt.Sprintf("attempt to change constant %s from %s to %s", name, old.Inspect(), val.Inspect())}
 			}
 		}

--- a/object/state.go
+++ b/object/state.go
@@ -85,7 +85,6 @@ func (e *Environment) Info() Object {
 	}
 	info := e.BaseInfo()
 	info[String{"all_ids"}] = allKeys
-	// TODO: Cache this as it can't change without recompiling:
 	return info
 }
 

--- a/object/state.go
+++ b/object/state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"fortio.org/cli"
 	"fortio.org/log"
 	"fortio.org/sets"
 	"grol.io/grol/token"
@@ -41,7 +42,7 @@ func (e *Environment) BaseInfo() Map {
 	if baseInfo != nil {
 		return baseInfo
 	}
-	baseInfo := make(Map, 4)
+	baseInfo := make(Map, 6) // 5 here + all_ids
 	tokInfo := token.Info()
 	keys := make([]Object, 0, len(tokInfo.Keywords))
 	for _, v := range sets.Sort(tokInfo.Keywords) {
@@ -62,6 +63,8 @@ func (e *Environment) BaseInfo() Map {
 	arr := Array{Elements: keys}
 	sort.Sort(arr)
 	baseInfo[String{"gofuncs"}] = arr
+	baseInfo[String{"version"}] = String{Value: cli.ShortVersion}
+	baseInfo[String{"platform"}] = String{Value: cli.LongVersion}
 	return baseInfo
 }
 

--- a/object/state.go
+++ b/object/state.go
@@ -2,13 +2,17 @@ package object
 
 import (
 	"fmt"
+	"sort"
 
 	"fortio.org/log"
+	"fortio.org/sets"
+	"grol.io/grol/token"
 )
 
 type Environment struct {
 	store    map[string]Object
 	outer    *Environment
+	depth    int
 	cacheKey string
 }
 
@@ -31,7 +35,61 @@ func (e *Environment) Len() int {
 	return len(e.store)
 }
 
+var baseInfo Map
+
+func (e *Environment) BaseInfo() Map {
+	if baseInfo != nil {
+		return baseInfo
+	}
+	baseInfo := make(Map, 4)
+	tokInfo := token.Info()
+	keys := make([]Object, 0, len(tokInfo.Keywords))
+	for _, v := range sets.Sort(tokInfo.Keywords) {
+		keys = append(keys, String{Value: v})
+	}
+	baseInfo[String{"keywords"}] = Array{Elements: keys}
+	keys = make([]Object, 0, len(tokInfo.Tokens))
+	for _, v := range sets.Sort(tokInfo.Tokens) {
+		keys = append(keys, String{Value: v})
+	}
+	baseInfo[String{"tokens"}] = Array{Elements: keys}
+	// Ditto cache this as it's set for a given environment.
+	ext := ExtraFunctions()
+	keys = make([]Object, 0, len(ext))
+	for k, _ := range ext {
+		keys = append(keys, String{Value: k})
+	}
+	arr := Array{Elements: keys}
+	sort.Sort(arr)
+	baseInfo[String{"gofuncs"}] = arr
+	return baseInfo
+}
+
+func (e *Environment) Info() Object {
+	allKeys := make(Map, e.depth)
+	for {
+		keys := make([]Object, 0, e.Len())
+		for k := range e.store {
+			keys = append(keys, String{Value: k})
+		}
+		arr := Array{Elements: keys}
+		sort.Sort(arr)
+		allKeys[Integer{Value: int64(e.depth)}] = arr
+		if e.outer == nil {
+			break
+		}
+		e = e.outer
+	}
+	info := e.BaseInfo()
+	info[String{"all_ids"}] = allKeys
+	// TODO: Cache this as it can't change without recompiling:
+	return info
+}
+
 func (e *Environment) Get(name string) (Object, bool) {
+	if name == "info" {
+		return e.Info(), true
+	}
 	obj, ok := e.store[name]
 	if ok || e.outer == nil {
 		return obj, ok
@@ -63,7 +121,7 @@ func (e *Environment) Set(name string, val Object) Object {
 		old, ok := e.Get(name) // not ok
 		if ok {
 			log.Infof("Attempt to change constant %s from %v to %v", name, old, val)
-			if !Hashable(old) || !Hashable(val) || old != val {
+			if Equals(old, val) == FALSE {
 				return Error{Value: fmt.Sprintf("attempt to change constant %s from %s to %s", name, old.Inspect(), val.Inspect())}
 			}
 		}
@@ -91,6 +149,6 @@ func NewFunctionEnvironment(fn Function, current *Environment) (*Environment, bo
 	if !sameFunction {
 		parent = fn.Env
 	}
-	env := &Environment{store: make(map[string]Object), outer: parent, cacheKey: fn.CacheKey}
+	env := &Environment{store: make(map[string]Object), outer: parent, cacheKey: fn.CacheKey, depth: parent.depth + 1}
 	return env, sameFunction
 }

--- a/token/info.go
+++ b/token/info.go
@@ -1,0 +1,16 @@
+package token
+
+import "fortio.org/sets"
+
+// Info enables introspection of known keywords and tokens and operators.
+type GrolInfo struct {
+	// Keywords is a map of all known keywords.
+	Keywords sets.Set[string]
+	Tokens   sets.Set[string]
+}
+
+var info = GrolInfo{}
+
+func Info() GrolInfo {
+	return info
+}

--- a/token/token.go
+++ b/token/token.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"fortio.org/sets"
 )
 
 // 'noCopy' Stolen from
@@ -156,6 +158,7 @@ func assoc(t Type, c byte) {
 	tok := &Token{tokenType: t, literal: string(c)}
 	cTokens[c] = tok
 	tToT[t] = tok
+	info.Tokens.Add(tok.literal)
 }
 
 func assocS(t Type, s string) *Token {
@@ -165,6 +168,7 @@ func assocS(t Type, s string) *Token {
 		panic("duplicate token for " + s)
 	}
 	tToT[t] = tok
+	info.Keywords.Add(s)
 	return tok
 }
 
@@ -179,10 +183,13 @@ func assocC2(t Type, str string) {
 	}
 	tToT[t] = tok
 	c2Tokens[[2]byte{str[0], str[1]}] = tok
+	info.Tokens.Add(str)
 }
 
 func Init() {
 	ResetInterning()
+	info.Keywords = sets.New[string]()
+	info.Tokens = sets.New[string]()
 	keywords = make(map[string]*Token)
 	cTokens = make(map[byte]*Token)
 	c2Tokens = make(map[[2]byte]*Token)
@@ -248,6 +255,7 @@ func Init() {
 	assocC2(DOTDOT, "..")
 	// Special alias for := to be same as ASSIGN.
 	c2Tokens[[2]byte{':', '='}] = cTokens['=']
+	info.Tokens.Add(":=")
 }
 
 //go:generate stringer -type=Type


### PR DESCRIPTION
- added `info` returning info map including identifiers stack (see README.md update for examples) and:
- made object.Array sortable replacing MapKeys
- use Equals in constant check and change objects Equals to stay native `bool` until last minute
- fix missing FLOAT handling


Example:
```go
$ info
{"all_ids":{0:["E","PI","abs","log2","printf"]},"gofuncs":["acos","asin","atan","ceil","cos","exp","floor","ln","log10","pow","round","sin","sprintf","sqrt","tan","trunc"],"keywords":["else","error","false","first","func","if","len","log","macro","print","println","quote","rest","return","true","unquote"],"platform":"dev  go1.22.5 arm64 darwin","tokens":["!","!=","%","(",")","*","+","++",",","-","--","..","/",":",":=",";","<","<=","=","==",">",">=","[","]","{","}"],"version":"dev"}
  ```
