### PR TITLE
set back the cli versions so info["version"] and info["platform"] do have the tag with tinygo/wasm

### DIFF
--- a/wasm/wasm_main.go
+++ b/wasm/wasm_main.go
@@ -49,6 +49,8 @@ func main() {
 	_, grolVersion, _ := version.FromBuildInfoPath("grol.io/grol")
 	if TinyGoVersion != "" { // tinygo doesn't have modules info in buildinfo nor tinygo install...
 		grolVersion = TinyGoVersion + " " + runtime.Compiler + runtime.Version() + " " + runtime.GOARCH + " " + runtime.GOOS
+		cli.LongVersion = grolVersion
+		cli.ShortVersion = TinyGoVersion
 	}
 	log.Infof("Grol wasm main %s", grolVersion)
 	done := make(chan struct{}, 0)


### PR DESCRIPTION
fixing https://grol.io/?c=println((info[%22version%22]))%0Ainfo[%22platform%22]