### PR TITLE
restrict by default, avoid security issues, force files to be alphanum.gr

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,19 +186,27 @@ flags:
     	command/inline script to run instead of interactive mode
   -compact
     	When printing code, use no indentation and most compact form
+  -empty-only
+    	only allow load()/save() to ./.gr
   -eval
     	show eval results (default true)
   -format
     	don't execute, just parse and re format the input
-  -history string
+  -history file
     	history file to use (default "~/.grol_history")
   -max-history size
     	max history size, use 0 to disable. (default 99)
+  -no-load-save
+    	disable load/save of history
   -parse
     	show parse tree
+  -quiet
+    	Quiet mode, sets loglevel to Error (quietly) to reduces the output
   -shared-state
     	All files share same interpreter state (default is new state for each)
+  -unrestricted-io
+    	enable unrestricted io (dangerous)
 ```
 (excluding logger control, see `gorepl help` for all the flags, of note `-logger-no-color` will turn off colors for gorepl too, for development there are also `-profile*` options for pprof, when building without `no_pprof`)
 
-If you don't want to pass a flag and want to permanently change the `grol` history file location from your HOME directory, set GROL_HISTORY_FILE in the environment.
+If you don't want to pass a flag and want to permanently change the `grol` history file location from your HOME directory, set `GROL_HISTORY_FILE` in the environment.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ variadic functions both Go side and grol side (using `..` on grol side)
 
 Use `info` to see all the available functions, keywords, operators etc... (can be used inside functions too to examine the stack)
 
+`save("filename")` and `load("filename")` current state.
+
 See also [sample.gr](examples/sample.gr) and others in that folder, that you can run with
 ```
 gorepl examples/*.gr

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	c := &extensions.ExtensionConfig{}
-	err := extensions.Init(c)
+	err := extensions.Init(nil)
 	if err != nil {
 		panic(err)
 	}
@@ -813,8 +812,7 @@ func testFloatObject(t *testing.T, obj object.Object, expected float64) bool {
 }
 
 func TestExtension(t *testing.T) {
-	c := &extensions.ExtensionConfig{}
-	err := extensions.Init(c)
+	err := extensions.Init(nil)
 	if err != nil {
 		t.Fatalf("extensions.Init() failed: %v", err)
 	}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	err := extensions.Init()
+	c := &extensions.ExtensionConfig{}
+	err := extensions.Init(c)
 	if err != nil {
 		panic(err)
 	}
@@ -812,7 +813,8 @@ func testFloatObject(t *testing.T, obj object.Object, expected float64) bool {
 }
 
 func TestExtension(t *testing.T) {
-	err := extensions.Init()
+	c := &extensions.ExtensionConfig{}
+	err := extensions.Init(c)
 	if err != nil {
 		t.Fatalf("extensions.Init() failed: %v", err)
 	}

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -22,16 +22,23 @@ var (
 	emptyOnly       = false
 )
 
+// Configure restrictions and features.
+// Currently about IOs of load and save functions.
 type ExtensionConfig struct {
-	HasLoad           bool
-	HasSave           bool
-	LoadSaveEmptyOnly bool
-	UnrestrictedIOs   bool // Dangerous, can overrwite files, read any readable file etc...
+	HasLoad           bool // load() only present if this is true.
+	HasSave           bool // save() only present if this is true.
+	LoadSaveEmptyOnly bool // Restrict load/save to a single .gr file inside the current directory.
+	UnrestrictedIOs   bool // Dangerous when true: can overwrite files, read any readable file etc...
 }
 
+// Init initializes the extensions, can be called multiple time safely but should really be called only once
+// before using GROL repl/eval. If the passed [ExtensionConfig] pointer is nil, default (safe) values are used.
 func Init(c *ExtensionConfig) error {
 	if initDone {
 		return errInInit
+	}
+	if c == nil {
+		c = &ExtensionConfig{}
 	}
 	errInInit = initInternal(c)
 	initDone = true

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -163,7 +163,7 @@ func (l *Lexer) peekChar() byte {
 
 func (l *Lexer) readIdentifier() string {
 	pos := l.pos - 1
-	for isAlphaNum(l.peekChar()) {
+	for IsAlphaNum(l.peekChar()) {
 		l.pos++
 	}
 	return string(l.input[pos:l.pos])
@@ -259,7 +259,7 @@ func isLetter(ch byte) bool {
 	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
 }
 
-func isAlphaNum(ch byte) bool {
+func IsAlphaNum(ch byte) bool {
 	return isLetter(ch) || isDigit(ch)
 }
 

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ func Main() int {
 	historyFile := flag.String("history", defaultHistoryFile, "history `file` to use")
 	maxHistory := flag.Int("max-history", terminal.DefaultHistoryCapacity, "max history `size`, use 0 to disable.")
 	disableLoadSave := flag.Bool("no-load-save", false, "disable load/save of history")
+	unrestrictedIOs := flag.Bool("unrestricted-io", false, "enable unrestricted io (dangerous)")
+	emptyOnly := flag.Bool("empty-only", false, "only allow load()/save() to ./.gr")
+
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
 	cli.Main()
@@ -84,7 +87,10 @@ func Main() int {
 		}
 	}
 	c := extensions.ExtensionConfig{
-		LoadAndSave: !*disableLoadSave,
+		HasLoad:           !*disableLoadSave,
+		HasSave:           !*disableLoadSave,
+		UnrestrictedIOs:   *unrestrictedIOs,
+		LoadSaveEmptyOnly: *emptyOnly,
 	}
 	err := extensions.Init(&c)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func Main() int {
 	}
 	historyFile := flag.String("history", defaultHistoryFile, "history `file` to use")
 	maxHistory := flag.Int("max-history", terminal.DefaultHistoryCapacity, "max history `size`, use 0 to disable.")
+	disableLoadSave := flag.Bool("no-load-save", false, "disable load/save of history")
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
 	cli.Main()
@@ -82,7 +83,10 @@ func Main() int {
 			return ret
 		}
 	}
-	err := extensions.Init()
+	c := extensions.ExtensionConfig{
+		LoadAndSave: !*disableLoadSave,
+	}
+	err := extensions.Init(&c)
 	if err != nil {
 		return log.FErrf("Error initializing extensions: %v", err)
 	}

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -127,6 +127,19 @@ grol -quiet -c 'n1={"f1":func(){println("f1")},"f2":func(x){x+1}}n1.f1()n1.f2(41
 stdout '^f1\n42$'
 !stderr .
 
+!grol -no-load-save -c 'save("foo.gr"); load("foo.gr")'
+stderr 'identifier not found: save'
+
+!grol -no-load-save -c 'load("foo.gr")'
+stderr 'identifier not found: load'
+
+!grol -c 'save("/tmp/foo.gr"); load("/tmp/foo.gr")'
+stderr 'Invalid character in filename "/tmp/foo.gr": /'
+
+grol -c 'load("fib_50")'
+stdout '^12586269025\n$'
+stderr 'Read/evaluated: fib_50.gr'
+
 -- foo.inp --
 foo
 -- sample_test.gr --

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -134,11 +134,25 @@ stderr 'identifier not found: save'
 stderr 'identifier not found: load'
 
 !grol -c 'save("/tmp/foo.gr"); load("/tmp/foo.gr")'
-stderr 'Invalid character in filename "/tmp/foo.gr": /'
+stderr 'invalid character in filename "/tmp/foo.gr": /'
 
 grol -c 'load("fib_50")'
 stdout '^12586269025\n$'
 stderr 'Read/evaluated: fib_50.gr'
+
+!grol -c 'load("./fib_50.gr")'
+stderr 'invalid character in filename "./fib_50.gr": \.'
+
+grol -unrestricted-io -c 'load("./fib_50.gr")'
+stdout '^12586269025\n$'
+stderr 'Read/evaluated: ./fib_50.gr'
+
+!grol -empty-only -c 'load("fib_50")'
+stderr 'empty only mode, filename must be empty or no arguments, got: "fib_50"'
+
+grol -empty-only -c 'save();load()'
+stderr 'Saved .* ids/fns to: .gr'
+stderr 'Read/evaluated: .gr'
 
 -- foo.inp --
 foo

--- a/wasm/wasm_main.go
+++ b/wasm/wasm_main.go
@@ -57,7 +57,8 @@ func main() {
 	global := js.Global()
 	global.Set("grol", js.FuncOf(jsEval))
 	global.Set("grolVersion", js.ValueOf(grolVersion))
-	err := extensions.Init()
+	// IOs don't work yet https://github.com/grol-io/grol/issues/124 otherwise we'd allow HasLoad HasSave.
+	err := extensions.Init(&extensions.ExtensionConfig{})
 	if err != nil {
 		log.Critf("Error initializing extensions: %v", err)
 	}


### PR DESCRIPTION
following options are added (with safe defaults)
```go
type ExtensionConfig struct {
	HasLoad           bool
	HasSave           bool
	LoadSaveEmptyOnly bool
	UnrestrictedIOs   bool // Dangerous, can overrwite files, read any readable file etc...
}
```

Fixes #126 