### PR TITLE
Don't autosave if nothing changed; Share logic for empty load/save; return filename and number of entries

### DIFF
--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -21,6 +21,7 @@ type State struct {
 	cache      Cache
 	extensions map[string]object.Extension
 	NoLog      bool // turn log() into println() (for EvalString)
+	lastNumSet int64
 }
 
 func NewState() *State {
@@ -64,6 +65,14 @@ func (s *State) Len() int {
 // Saves the top level (global) environment.
 func (s *State) SaveGlobals(w io.Writer) (int, error) {
 	return s.env.SaveGlobals(w)
+}
+
+// NumSet returns the previous and current cumulative number of set in the toplevel environment, if that
+// number hasn't changed, no need to autosave.
+func (s *State) UpdateNumSet() (int64, int64) {
+	prev := s.lastNumSet
+	s.lastNumSet = s.env.NumSet()
+	return s.lastNumSet, prev
 }
 
 // Does unwrap (so stop bubbling up) return values.

--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -69,10 +69,11 @@ func (s *State) SaveGlobals(w io.Writer) (int, error) {
 
 // NumSet returns the previous and current cumulative number of set in the toplevel environment, if that
 // number hasn't changed, no need to autosave.
-func (s *State) UpdateNumSet() (int64, int64) {
-	prev := s.lastNumSet
-	s.lastNumSet = s.env.NumSet()
-	return s.lastNumSet, prev
+func (s *State) UpdateNumSet() (oldvalue, newvalue int64) {
+	oldvalue = s.lastNumSet
+	newvalue = s.env.NumSet()
+	s.lastNumSet = newvalue
+	return
 }
 
 // Does unwrap (so stop bubbling up) return values.

--- a/object/state.go
+++ b/object/state.go
@@ -19,6 +19,7 @@ type Environment struct {
 	depth    int
 	cacheKey string
 	ids      *trie.Trie
+	numSet   int64
 }
 
 // Truly empty store suitable for macros storage.
@@ -180,8 +181,15 @@ func Constant(name string) bool {
 	return true
 }
 
+// NumSet returns the cumulative number of set operations done in the toplevel environment so far.
+// It can be used to avoid calling SaveGlobals if nothing has changed since the last time.
+func (e *Environment) NumSet() int64 {
+	return e.numSet
+}
+
 func (e *Environment) SetNoChecks(name string, val Object) Object {
 	if e.depth == 0 {
+		e.numSet++
 		if _, ok := e.store[name]; !ok {
 			// new top level entry, record it.
 			record(e.ids, name, val.Type())

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -77,13 +77,20 @@ func AutoLoad(s *eval.State, options Options) error {
 	}
 	// Eval the content.
 	_, err = eval.EvalString(s, string(all), false)
-	log.Infof("Auto loaded %s", AutoSaveFile)
+	_, numset := s.UpdateNumSet()
+	log.Infof("Auto loaded %s (%d set)", AutoSaveFile, numset)
 	return err
 }
 
 func AutoSave(s *eval.State, options Options) error {
 	if !options.AutoSave {
 		log.Debugf("Autosave disabled")
+		return nil
+	}
+	newS, oldS := s.UpdateNumSet()
+	updates := newS - oldS
+	if updates == 0 {
+		log.Infof("Nothing changed, not auto saving")
 		return nil
 	}
 	f, err := os.CreateTemp(".", ".grol*.tmp")
@@ -100,7 +107,7 @@ func AutoSave(s *eval.State, options Options) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Auto saved %d ids/fns to: %s", n, AutoSaveFile)
+	log.Infof("Auto saved %d ids/fns (%d set) to: %s", n, updates, AutoSaveFile)
 	return nil
 }
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -87,7 +87,7 @@ func AutoSave(s *eval.State, options Options) error {
 		log.Debugf("Autosave disabled")
 		return nil
 	}
-	newS, oldS := s.UpdateNumSet()
+	oldS, newS := s.UpdateNumSet()
 	updates := newS - oldS
 	if updates == 0 {
 		log.Infof("Nothing changed, not auto saving")


### PR DESCRIPTION
- Share logic for empty load/save (review comment from [#126](https://github.com/grol-io/grol/pull/127#discussion_r1713711476))
- return filename and number of entries
```go
$ save("foo")
09:05:11.189 [INF] Saved 8 ids/fns to: foo.gr
{"entries":8,"filename":"foo.gr"}
```
- #129 


Fixes #129 