### PR TITLE
Get rid of regexp, save 250kb on binary size, tweak install, fix bug with !n history off by one when full, nil/NaN/Inf ids, map append fix, array[nil]==array[0]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,11 @@ wasm-release: Makefile *.go */*.go $(GEN) wasm/wasm_exec.js wasm/wasm_exec.html
 	mv "$(shell go env GOPATH)/bin/js_wasm/wasm" wasm/grol.wasm
 	ls -lh wasm/*.wasm
 
+install:
+	CGO_ENABLED=0 go install -trimpath -ldflags="-w -s" -tags "$(GO_BUILD_TAGS)" grol.io/grol@$(GIT_TAG)
+	ls -lh "$(shell go env GOPATH)/bin/grol"
+	grol version
+
 wasm/wasm_exec.js: Makefile
 #	cp "$(shell tinygo env TINYGOROOT)/targets/wasm_exec.js" ./wasm/
 	cp "$(shell go env GOROOT)/misc/wasm/wasm_exec.js" ./wasm/
@@ -100,4 +105,4 @@ lint: .golangci.yml
 .golangci.yml: Makefile
 	curl -fsS -o .golangci.yml https://raw.githubusercontent.com/fortio/workflows/main/golangci.yml
 
-.PHONY: all lint generate test clean run build wasm tinygo wasm-release tiny_test tinygo-tests check
+.PHONY: all lint generate test clean run build wasm tinygo wasm-release tiny_test tinygo-tests check install

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is also now a [discord bot](https://github.com/grol-io/grol-discord-bot#gr
 
 Install/run it:
 ```shell
-CGO_ENABLED=0 go install -trimpath -ldflags="-w -s" -tags no_net,no_json grol.io/grol@latest
+CGO_ENABLED=0 go install -trimpath -ldflags="-w -s" -tags "no_net,no_json,no_pprof" grol.io/grol@latest
 ```
 
 Or with docker:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -333,16 +333,20 @@ func evalRest(val object.Object) object.Object {
 }
 
 func evalIndexExpression(left, index object.Object) object.Object {
+	idxOrZero := index
+	if idxOrZero.Type() == object.NIL {
+		idxOrZero = object.Integer{Value: 0}
+	}
 	switch {
-	case left.Type() == object.STRING && index.Type() == object.INTEGER:
-		idx := index.(object.Integer).Value
+	case left.Type() == object.STRING && idxOrZero.Type() == object.INTEGER:
+		idx := idxOrZero.(object.Integer).Value
 		str := left.(object.String).Value
 		if idx < 0 || idx >= int64(len(str)) {
 			return object.NULL
 		}
 		return object.Integer{Value: int64(str[idx])}
-	case left.Type() == object.ARRAY && index.Type() == object.INTEGER:
-		return evalArrayIndexExpression(left, index)
+	case left.Type() == object.ARRAY && idxOrZero.Type() == object.INTEGER:
+		return evalArrayIndexExpression(left, idxOrZero)
 	case left.Type() == object.MAP:
 		return evalMapIndexExpression(left, index)
 	case left.Type() == object.NIL:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -578,6 +578,9 @@ func (s *State) evalPrefixExpression(operator token.Type, right object.Object) o
 		return s.evalBangOperatorExpression(right)
 	case token.MINUS:
 		return s.evalMinusPrefixOperatorExpression(right)
+	case token.PLUS:
+		// nothing do with unary plus, just return the value.
+		return right
 	default:
 		return object.Error{Value: "unknown operator: " + operator.String()}
 	}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -261,13 +261,7 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 		}
 	}
 	switch t { //nolint:exhaustive // we have defaults and covering all the builtins.
-	case token.ERROR:
-		fallthrough
-	case token.PRINT:
-		fallthrough
-	case token.PRINTLN:
-		fallthrough
-	case token.LOG:
+	case token.ERROR, token.PRINT, token.PRINTLN, token.LOG:
 		return s.evalPrintLogError(node)
 	case token.FIRST:
 		return evalFirst(val)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -345,6 +345,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 		return evalArrayIndexExpression(left, index)
 	case left.Type() == object.MAP:
 		return evalMapIndexExpression(left, index)
+	case left.Type() == object.NIL:
+		return object.NULL
 	default:
 		return object.Error{Value: "index operator not supported: " + left.Type().String() + "[" + index.Type().String() + "]"}
 	}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -912,3 +912,17 @@ func TestBlankSlateEval(t *testing.T) {
 	_, _ = eval.EvalString(s, inp, true)
 	t.Fatalf("should have panicked and not reach")
 }
+
+func TestMapAccidentalMutation(t *testing.T) {
+	inp := `m={1:1, nil:"foo"}; m+{nil:"bar"}; m`
+	s := eval.NewState()
+	res, err := eval.EvalString(s, inp, false)
+	if err != nil {
+		t.Fatalf("should not have errored: %v", err)
+	}
+	resStr := res.Inspect()
+	expected := `{1:1,nil:"foo"}`
+	if resStr != expected {
+		t.Fatalf("wrong result, got %q expected %q", resStr, expected)
+	}
+}

--- a/examples/explode.gr
+++ b/examples/explode.gr
@@ -1,0 +1,22 @@
+// Turn a string into an array of byte values
+
+// Take a var arg and return first value or 0.
+func optint(a) {
+	if len(a) == 0 {
+		0
+	} else {
+		a[0]
+	}
+}
+// Use var arg trick to not need to define an inner lambda.
+func explode(s, ..) {
+	i = optint(..)
+	if i >= len(s) {
+		[]
+	} else {
+		[(s[i])] + self(s, i + 1)
+	}
+}
+
+println("ABC -> ", explode("ABC"))
+// ^ [65,66,67]

--- a/examples/keys.gr
+++ b/examples/keys.gr
@@ -1,0 +1,12 @@
+
+m = {1:"a", 3:"b", 5:"c", 7:"d"}
+
+func keys(m) {
+    if (len(m)==0) {
+        return []
+    }
+    return [first(m).key]+keys(rest(m))
+}
+
+keys(m)
+// ^^^ [1,3,5,7]

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -94,7 +94,7 @@ func initInternal(c *Config) error {
 	}
 	object.AddIdentifier("nil", object.NULL)
 	object.AddIdentifier("NaN", object.Float{Value: math.NaN()})
-	object.AddIdentifier("Inf", object.Float{Value: math.Inf(0)}) // works for -Inf and will for +Inf once we support unary plus.
+	object.AddIdentifier("Inf", object.Float{Value: math.Inf(0)}) // Works for both -Inf and +Inf (thanks to noop unary +).
 
 	oneFloat := object.Extension{
 		MinArgs:  1,

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -92,6 +92,10 @@ func initInternal(c *Config) error {
 	if err != nil {
 		return err
 	}
+	object.AddIdentifier("nil", object.NULL)
+	object.AddIdentifier("NaN", object.Float{Value: math.NaN()})
+	object.AddIdentifier("Inf", object.Float{Value: math.Inf(0)}) // works for -Inf and will for +Inf once we support unary plus.
+
 	oneFloat := object.Extension{
 		MinArgs:  1,
 		MaxArgs:  1,

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -160,6 +160,10 @@ grol -no-auto -quiet -c 'm={2:"b"};n={1:"a"};println(m+n); println(m)'
 stdout '^{1:"a",2:"b"}\n{2:"b"}$'
 !stderr .
 
+grol -no-auto -quiet -c 'm={1:1, nil:"foo"}; println(m+{nil:"bar"}); m'
+stdout '^{1:1,nil:"bar"}\n{1:1,nil:"foo"}$'
+!stderr .
+
 -- sample_test.gr --
 // Sample file that our gorepl can interpret
 // <--- comments

--- a/object/object.go
+++ b/object/object.go
@@ -53,7 +53,7 @@ type Number interface {
 }
 */
 
-// Hashable in tem of go map for cache key.
+// Hashable in tem of Go map for cache key.
 func Hashable(o Object) bool {
 	switch o.Type() { //nolint:exhaustive // We have all the types that are hashable + default for the others.
 	case INTEGER, FLOAT, BOOLEAN, NIL, ERROR, STRING:
@@ -77,7 +77,7 @@ func Equals(left, right Object) bool {
 	return Cmp(left, right) == 0
 }
 
-func Cmp(ei, ej Object) int { //nolint:gocyclo // We have a lot of types to compare.
+func Cmp(ei, ej Object) int {
 	ti := ei.Type()
 	tj := ej.Type()
 	if areIntFloat(ti, tj) {
@@ -159,15 +159,7 @@ func Cmp(ei, ej Object) int { //nolint:gocyclo // We have a lot of types to comp
 		return cmp.Compare(ei.(String).Value, ej.(String).Value)
 
 	// RETURN, QUOTE, MACRO, ANY aren't expected to be compared.
-	case RETURN:
-		fallthrough
-	case QUOTE:
-		fallthrough
-	case MACRO:
-		fallthrough
-	case UNKNOWN:
-		fallthrough
-	case ANY:
+	case RETURN, QUOTE, MACRO, UNKNOWN, ANY:
 		panic(fmt.Sprintf("Unexpected type in Cmp: %s", ti))
 	}
 	return 1
@@ -206,7 +198,7 @@ func CompareKeys(a, b KV) int {
 
 func (m *Map) Get(key Object) (Object, bool) {
 	kv := KV{Key: key}
-	i, ok := slices.BinarySearchFunc(m.kv, kv, CompareKeys)
+	i, ok := slices.BinarySearchFunc(m.kv, kv, CompareKeys) // log(n) search as we keep it sorted.
 	if !ok {
 		return NULL, false
 	}
@@ -472,8 +464,7 @@ func (ao Array) JSON(w io.Writer) error {
 	return err
 }
 
-// possible optimization: us a map of any and put the inner value of object in there, would be faster than
-// wrapping strings etc into object.
+// KeyValue pairs, what we have inside Map.
 type KV struct {
 	Key   Object
 	Value Object

--- a/object/object.go
+++ b/object/object.go
@@ -248,9 +248,9 @@ func (m *Map) Rest() Object {
 
 // Creates a new Map appending the right map to the left map.
 func (m *Map) Append(right *Map) *Map {
-	// important to avoid underlying array mutation.
-	// note: when we do map mutations, will need to copy instead.
-	res := &Map{kv: m.kv[:len(m.kv):len(m.kv)]}
+	// allocate for case of all unique keys.
+	res := &Map{kv: make([]KV, 0, len(m.kv)+len(right.kv))}
+	res.kv = append(res.kv, m.kv...)
 	for _, kv := range right.kv {
 		res.Set(kv.Key, kv.Value)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -83,6 +83,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.PLUS, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)


### PR DESCRIPTION
- #144 Get rid of regexp save 250kb on binary size
- Tweak install, add `make install`
- #145 Fix bug with !n history off by one when full
- Add nil,NaN,Inf identifiers
- Allow nil[whichever] -> nil
- Add unary + (prefix + == noop)
- #148 
- Fix bug where append (+) on map with same key would mutate the original

fixes #144 
fixes #145 
fixes #148 