### PR TITLE
Make join/split seperator argument optional, add `*` operator on arrays

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -709,6 +709,20 @@ func evalStringInfixExpression(operator token.Type, left, right object.Object) o
 func evalArrayInfixExpression(operator token.Type, left, right object.Object) object.Object {
 	leftVal := left.(object.Array).Elements
 	switch operator { //nolint:exhaustive // we have default.
+	case token.ASTERISK: // repeat
+		if right.Type() != object.INTEGER {
+			return object.Error{Value: "right operand of * on arrays must be an integer"}
+		}
+		// TODO: go1.23 use	slices.Repeat
+		rightVal := right.(object.Integer).Value
+		if rightVal < 0 {
+			return object.Error{Value: "right operand of * on arrays must be a positive integer"}
+		}
+		result := make([]object.Object, 0, len(leftVal)*int(rightVal))
+		for range rightVal {
+			result = append(result, leftVal...)
+		}
+		return object.Array{Elements: result}
 	case token.PLUS: // concat / append
 		if right.Type() != object.ARRAY {
 			return object.Array{Elements: append(leftVal, right)}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -416,9 +416,8 @@ func evalArrayIndexExpression(array, index object.Object) object.Object {
 func (s *State) applyExtension(fn object.Extension, args []object.Object) object.Object {
 	l := len(args)
 	log.Debugf("apply extension %s variadic %t : %d args %v", fn.Inspect(), fn.Variadic, l, args)
-	if fn.Variadic {
-		// In theory we should only do that if the last arg was ".." and not any array, but
-		// that could be a useful feature too.
+	if fn.MaxArgs == -1 {
+		// Only do this for true variadic functions (maxargs == -1)
 		if l > 0 && args[l-1].Type() == object.ARRAY {
 			args = append(args[:l-1], args[l-1].(object.Array).Elements...)
 			l = len(args)

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -217,12 +217,15 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		return err
 	}
 	strFn.Name = "split"
-	strFn.MinArgs = 2
+	strFn.MinArgs = 1
 	strFn.MaxArgs = 2
 	strFn.ArgTypes = []object.Type{object.STRING, object.STRING}
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		inp := args[0].(object.String).Value
-		sep := args[1].(object.String).Value
+		sep := ""
+		if len(args) == 2 {
+			sep = args[1].(object.String).Value
+		}
 		parts := strings.Split(inp, sep)
 		strs := make([]object.Object, len(parts))
 		for i, p := range parts {
@@ -238,7 +241,10 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	strFn.ArgTypes = []object.Type{object.ARRAY, object.STRING}
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		arr := args[0].(object.Array).Elements
-		sep := args[1].(object.String).Value
+		sep := ""
+		if len(args) == 2 {
+			sep = args[1].(object.String).Value
+		}
 		strs := make([]string, len(arr))
 		for i, a := range arr {
 			if a.Type() != object.STRING {

--- a/object/object.go
+++ b/object/object.go
@@ -593,7 +593,7 @@ type Extension struct {
 	MaxArgs  int         // Maximum number of arguments allowed. -1 for unlimited.
 	ArgTypes []Type      // Type of each argument, provided at least up to MinArgs.
 	Callback ExtFunction // The go function or lambda to call when the grol by Name(...) is invoked.
-	Variadic bool        // MaxArgs > MinArgs
+	Variadic bool        // MaxArgs > MinArgs (or MaxArg == -1)
 }
 
 // Adapter for functions that only need the argumants.
@@ -620,22 +620,23 @@ func (e *Extension) Usage(out *strings.Builder) {
 		t := strings.ToLower(e.ArgTypes[i-1].String())
 		out.WriteString(t)
 	}
+	prefix := ", "
+	if e.MinArgs == 0 {
+		prefix = ""
+	}
 	switch {
 	case e.MaxArgs < 0:
 		out.WriteString(", ..")
-	case e.MinArgs == 0 && e.MaxArgs == 1:
+	case e.MaxArgs == e.MinArgs+1: // only 1 extra optional argument.
 		arg := "arg"
-		if len(e.ArgTypes) > 0 {
-			arg = strings.ToLower(e.ArgTypes[0].String())
+		if len(e.ArgTypes) > e.MinArgs {
+			arg = strings.ToLower(e.ArgTypes[e.MinArgs].String())
 		}
+		out.WriteString(prefix)
 		out.WriteString("[") // to indicate optional
 		out.WriteString(arg)
 		out.WriteString("]")
 	case e.MaxArgs > e.MinArgs:
-		prefix := ", "
-		if e.MinArgs == 0 {
-			prefix = ""
-		}
 		out.WriteString(fmt.Sprintf("%sarg%d..arg%d", prefix, e.MinArgs+1, e.MaxArgs))
 	}
 }


### PR DESCRIPTION
- Make join/split seperator argument optional

also fixed up the usage string 
```
$ load
load([string])
$ join
join(array, [string])
$ sprintf
sprintf(string, ..)
```

- inspired by reading the go 1.23 release notes: our own slices.Repeat