### PR TITLE
Solve/avoid OOM kills and memory fatals by doing our own checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_BUILD_TAGS:=no_net,no_json,no_pprof
 
 run: grol
 	# Interactive debug run: use logger with file and line numbers
-	LOGGER_IGNORE_CLI_MODE=true ./grol -parse -loglevel debug
+	LOGGER_IGNORE_CLI_MODE=true GOMEMLIMIT=1GiB ./grol -parse -loglevel debug
 
 GEN:=object/type_string.go parser/priority_string.go token/type_string.go
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ wasm/wasm_exec.html:
 
 test: grol
 	CGO_ENABLED=0 go test -tags $(GO_BUILD_TAGS) ./...
-	./grol examples/*.gr
+	GOMEMLIMIT=1GiB ./grol examples/*.gr
 
 check: grol
 	./check_samples_double_format.sh examples/*.gr

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use `info` to see all the available functions, keywords, operators etc... (can b
 
 See also [sample.gr](examples/sample.gr) and others in that folder, that you can run with
 ```
-gorepl examples/*.gr
+grol examples/*.gr
 ```
 
 or copypaste to the online version on [grol.io](https://grol.io)

--- a/check_samples_double_format.sh
+++ b/check_samples_double_format.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 set -e
+export GOMEMLIMIT=1GiB
 for file in "$@"; do
     echo "---testing double format for $file---"
     ./grol -format $file > /tmp/format1

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -699,6 +699,8 @@ func evalStringInfixExpression(operator token.Type, left, right object.Object) o
 		return object.String{Value: leftVal + rightVal}
 	case operator == token.ASTERISK && right.Type() == object.INTEGER:
 		rightVal := right.(object.Integer).Value
+		n := len(leftVal) * int(rightVal)
+		object.MustBeOk(n / object.ObjectSize)
 		return object.String{Value: strings.Repeat(leftVal, int(rightVal))}
 	default:
 		return object.Error{Value: fmt.Sprintf("unknown operator: %s %s %s",
@@ -718,7 +720,7 @@ func evalArrayInfixExpression(operator token.Type, left, right object.Object) ob
 		if rightVal < 0 {
 			return object.Error{Value: "right operand of * on arrays must be a positive integer"}
 		}
-		result := make([]object.Object, 0, len(leftVal)*int(rightVal))
+		result := object.MakeObjectSlice(len(leftVal) * int(rightVal))
 		for range rightVal {
 			result = append(result, leftVal...)
 		}
@@ -727,7 +729,9 @@ func evalArrayInfixExpression(operator token.Type, left, right object.Object) ob
 		if right.Type() != object.ARRAY {
 			return object.Array{Elements: append(leftVal, right)}
 		}
-		return object.Array{Elements: append(leftVal, right.(object.Array).Elements...)}
+		rightArr := right.(object.Array).Elements
+		object.MustBeOk(len(leftVal) + len(rightArr))
+		return object.Array{Elements: append(leftVal, rightArr...)}
 	default:
 		return object.Error{Value: fmt.Sprintf("unknown operator: %s %s %s",
 			left.Type(), operator, right.Type())}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -548,7 +548,7 @@ func extendFunctionEnv(
 }
 
 func (s *State) evalExpressions(exps []ast.Node) ([]object.Object, *object.Error) {
-	result := make([]object.Object, 0, len(exps))
+	result := object.MakeObjectSlice(len(exps)) // not that this one can ever be huge but, for consistency.
 	for _, e := range exps {
 		evaluated := s.evalInternal(e)
 		if rt := evaluated.Type(); rt == object.ERROR {

--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -26,9 +26,10 @@ type State struct {
 	NoLog      bool // turn log() into println() (for EvalString)
 	// Max depth / recursion level - default DefaultMaxDepth,
 	// note that a simple function consumes at least 2 levels and typically at least 3 or 4.
-	MaxDepth   int
-	depth      int // current depth / recursion level
-	lastNumSet int64
+	MaxDepth    int
+	depth       int // current depth / recursion level
+	lastNumSet  int64
+	MaxValueLen int // max length of value to save in files, <= 0 for unlimited.
 }
 
 func NewState() *State {
@@ -74,7 +75,7 @@ func (s *State) Len() int {
 // Save() saves the current toplevel state (ids and functions) to the writer, forwards to the object store.
 // Saves the top level (global) environment.
 func (s *State) SaveGlobals(w io.Writer) (int, error) {
-	return s.env.SaveGlobals(w)
+	return s.env.SaveGlobals(w, s.MaxValueLen)
 }
 
 // NumSet returns the previous and current cumulative number of set in the toplevel environment, if that

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -250,14 +250,17 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 			sep = args[1].(object.String).Value
 		}
 		strs := make([]string, len(arr))
+		totalLen := 0
+		sepLen := len(sep)
 		for i, a := range arr {
 			if a.Type() != object.STRING {
 				strs[i] = a.Inspect()
 			} else {
 				strs[i] = a.(object.String).Value
 			}
+			totalLen += len(strs[i]) + sepLen
 		}
-		object.MustBeOk((len(strs) * len(sep)) / object.ObjectSize)
+		object.MustBeOk(totalLen / object.ObjectSize) // off by sepLen but that's ok.
 		return object.String{Value: strings.Join(strs, sep)}
 	}
 	err = object.CreateFunction(strFn)

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -190,7 +190,9 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		inp := args[0].(object.String).Value
 		gorunes := []rune(inp)
-		runes := make([]object.Object, len(gorunes))
+		l := len(gorunes)
+		object.MustBeOk(l)
+		runes := make([]object.Object, l)
 		for i, r := range gorunes {
 			runes[i] = object.String{Value: string(r)}
 		}
@@ -227,7 +229,9 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 			sep = args[1].(object.String).Value
 		}
 		parts := strings.Split(inp, sep)
-		strs := make([]object.Object, len(parts))
+		l := len(parts)
+		object.MustBeOk(l)
+		strs := make([]object.Object, l)
 		for i, p := range parts {
 			strs[i] = object.String{Value: p}
 		}
@@ -253,6 +257,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 				strs[i] = a.(object.String).Value
 			}
 		}
+		object.MustBeOk((len(strs) * len(sep)) / object.ObjectSize)
 		return object.String{Value: strings.Join(strs, sep)}
 	}
 	err = object.CreateFunction(strFn)

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"fortio.org/cli"
 	"fortio.org/log"
@@ -74,6 +76,10 @@ func Main() int {
 		}
 	}
 	log.Infof("grol %s - welcome!", cli.LongVersion)
+	memlimit := debug.SetMemoryLimit(-1)
+	if memlimit == math.MaxInt64 {
+		log.Warnf("Memory limit not set, please set GOMEMLIMIT=1GiB or similar")
+	}
 	options := repl.Options{
 		ShowParse:   *showParse,
 		ShowEval:    *showEval,

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func Main() int {
 	log.Infof("grol %s - welcome!", cli.LongVersion)
 	memlimit := debug.SetMemoryLimit(-1)
 	if memlimit == math.MaxInt64 {
-		log.Warnf("Memory limit not set, please set GOMEMLIMIT=1GiB or similar")
+		log.Warnf("Memory limit not set, please set the GOMEMLIMIT env var; e.g. GOMEMLIMIT=1GiB")
 	}
 	options := repl.Options{
 		ShowParse:   *showParse,

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func Main() int {
 	emptyOnly := flag.Bool("empty-only", false, "only allow load()/save() to ./.gr")
 	noAuto := flag.Bool("no-auto", false, "don't auto load/save the state to ./.gr")
 	maxDepth := flag.Int("max-depth", eval.DefaultMaxDepth-1, "Maximum interpreter depth")
+	maxLen := flag.Int("max-save-len", 4000, "Maximum len of saved identifiers, use 0 for unlimited")
 
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
@@ -90,6 +91,7 @@ func Main() int {
 		AutoLoad:    !*noAuto,
 		AutoSave:    !*noAuto,
 		MaxDepth:    *maxDepth + 1,
+		MaxValueLen: *maxLen,
 	}
 	if hookBefore != nil {
 		ret := hookBefore()

--- a/object/memory.go
+++ b/object/memory.go
@@ -15,6 +15,7 @@ func FreeMemory() int64 {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 	currentAlloc := memStats.HeapAlloc
+	// retrieve the current limit.
 	gomemlimit := debug.SetMemoryLimit(-1)
 	return int64(gomemlimit) - int64(currentAlloc) //nolint:unconvert // necessary, can be negative.
 }

--- a/object/memory.go
+++ b/object/memory.go
@@ -1,0 +1,44 @@
+package object
+
+import (
+	"fmt"
+	"math/bits"
+	"runtime"
+	"runtime/debug"
+)
+
+// Size of the Object interface in bytes.
+const ObjectSize = 2 * bits.UintSize / 8 // also unsafe.Sizeof(interface) == 16 bytes (2 pointers == 2 ints)
+
+// Returns the amount of free memory in bytes.
+func FreeMemory() int64 {
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	currentAlloc := memStats.HeapAlloc
+	gomemlimit := debug.SetMemoryLimit(-1)
+	return int64(gomemlimit) - int64(currentAlloc) //nolint:unconvert // necessary, can be negative.
+}
+
+func SizeOk(n int) (bool, int64) {
+	if n <= 256 { // no checks for small slices (4k memory/one typical page)
+		return true, 0
+	}
+	free := FreeMemory()
+	return ((free >= 0) && ((int64(n) * ObjectSize) < free)), free
+}
+
+func MustBeOk(n int) {
+	if ok, _ := SizeOk(n); ok {
+		return
+	}
+	runtime.GC()
+	if ok, free := SizeOk(n); !ok {
+		panic(fmt.Sprintf("would exceed memory requesting %d objects, %d free", n, free))
+	}
+}
+
+// Memory checking version of make(). To avoid OOM kills / fatal errors.
+func MakeObjectSlice(n int) []Object {
+	MustBeOk(n)
+	return make([]Object, 0, n)
+}

--- a/object/object.go
+++ b/object/object.go
@@ -249,8 +249,9 @@ func (m *Map) Rest() Object {
 // Creates a new Map appending the right map to the left map.
 func (m *Map) Append(right *Map) *Map {
 	// allocate for case of all unique keys.
-	MustBeOk(2 * (len(m.kv) + len(right.kv))) // KV is 2 Objects.
-	res := &Map{kv: make([]KV, 0, len(m.kv)+len(right.kv))}
+	nl := len(m.kv) + len(right.kv)
+	MustBeOk(2 * nl) // KV is 2 Objects.
+	res := &Map{kv: make([]KV, 0, nl)}
 	res.kv = append(res.kv, m.kv...)
 	for _, kv := range right.kv {
 		res.Set(kv.Key, kv.Value)

--- a/object/object.go
+++ b/object/object.go
@@ -249,6 +249,7 @@ func (m *Map) Rest() Object {
 // Creates a new Map appending the right map to the left map.
 func (m *Map) Append(right *Map) *Map {
 	// allocate for case of all unique keys.
+	MustBeOk(2 * (len(m.kv) + len(right.kv))) // KV is 2 Objects.
 	res := &Map{kv: make([]KV, 0, len(m.kv)+len(right.kv))}
 	res.kv = append(res.kv, m.kv...)
 	for _, kv := range right.kv {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -58,7 +58,8 @@ type Options struct {
 	MaxHistory  int
 	AutoLoad    bool
 	AutoSave    bool
-	MaxDepth    int
+	MaxDepth    int // Max depth of recursion, 0 is keeping the default (eval.DefaultMaxDepth).
+	MaxValueLen int // Maximum len of a value when using save()/autosaving, 0 is unlimited.
 }
 
 func AutoLoad(s *eval.State, options Options) error {
@@ -163,6 +164,7 @@ func EvalStringWithOption(o Options, what string) (res string, errs []string, fo
 	if o.MaxDepth > 0 {
 		s.MaxDepth = o.MaxDepth
 	}
+	s.MaxValueLen = o.MaxValueLen // 0 is unlimited so ok to copy as is.
 	out := &strings.Builder{}
 	s.Out = out
 	s.LogOut = out
@@ -191,6 +193,7 @@ func Interactive(options Options) int {
 	options.NilAndErr = true
 	s := eval.NewState()
 	s.MaxDepth = options.MaxDepth
+	s.MaxValueLen = options.MaxValueLen // 0 is unlimited so ok to copy as is.
 	term, err := terminal.Open()
 	if err != nil {
 		return log.FErrf("Error creating readline: %v", err)


### PR DESCRIPTION
so

```
GOMEMLIMIT=10GiB ./grol

$ len([1,2,3]*200_000_000)
600000000
$ len([1,2,3]*300_000_000)
10:59:22.702 [CRI] Caught panic: would exceed memory requesting 900000000 objects, 10736636880 free
$ len("ABC"*3_000_000_000)
9000000000
$ len("ABC"*4_000_000_000)
10:58:09.054 [CRI] Caught panic: would exceed memory requesting 750000000 objects, 10736643576 free
```

also to limit IOs:
```
$ long=["ABC"]*1000
[...]
11:22:00.014 [INF] Exit requested
11:22:00.016 [WRN] Skipping "long" as it's too long (6001 > 4000)
11:22:00.016 [INF] Auto saved 30 ids/fns (1 set) to: .gr
```


this originates from stepping on https://github.com/ldemailly/go-scratch/blob/main/membug/membug.go ie you can allocate 10x the limit and get no error, until you get OOM killed _or_ fatal, but no recoverable error, this makes it recoverable
