### PR TITLE
Introduce SmallArray to cache smaller arrays in memoization cache. new `-panic` option for development/debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_BUILD_TAGS:=no_net,no_json,no_pprof
 
 run: grol
 	# Interactive debug run: use logger with file and line numbers
-	LOGGER_IGNORE_CLI_MODE=true GOMEMLIMIT=1GiB ./grol -parse -loglevel debug
+	LOGGER_IGNORE_CLI_MODE=true GOMEMLIMIT=1GiB ./grol -panic -parse -loglevel debug
 
 GEN:=object/type_string.go parser/priority_string.go token/type_string.go
 

--- a/check_samples_double_format.sh
+++ b/check_samples_double_format.sh
@@ -1,18 +1,19 @@
 #! /bin/bash
 set -e
 export GOMEMLIMIT=1GiB
+BIN="./grol -panic"
 for file in "$@"; do
     echo "---testing double format for $file---"
-    ./grol -format "$file" > /tmp/format1
-    ./grol -format /tmp/format1 > /tmp/format2
+    $BIN -format "$file" > /tmp/format1
+    $BIN -format /tmp/format1 > /tmp/format2
     diff -u /tmp/format1 /tmp/format2
-    ./grol "$file" > /tmp/output1
-    ./grol /tmp/format2 > /tmp/output2
+    $BIN "$file" > /tmp/output1
+    $BIN /tmp/format2 > /tmp/output2
     diff -u /tmp/output1 /tmp/output2
-    ./grol -format -compact "$file" > /tmp/format3
-    ./grol -format -compact /tmp/format3 > /tmp/format4
+    $BIN -format -compact "$file" > /tmp/format3
+    $BIN -format -compact /tmp/format3 > /tmp/format4
     diff -u /tmp/format3 /tmp/format4
-    ./grol /tmp/format4 > /tmp/output3
+    $BIN /tmp/format4 > /tmp/output3
     diff -u /tmp/output1 /tmp/output3
     echo "---done---"
 done

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -495,19 +495,19 @@ func TestArrayLiterals(t *testing.T) {
 	input := "[1, 2 * 2, 3 + 3]"
 
 	evaluated := testEval(t, input)
-	result, ok := evaluated.(object.Array)
+	result, ok := evaluated.(object.SmallArray)
 	if !ok {
 		t.Fatalf("object is not Array. got=%T (%+v)", evaluated, evaluated)
 	}
-
-	if len(result.Elements) != 3 {
+	els := object.Elements(result)
+	if len(els) != 3 {
 		t.Fatalf("array has wrong num of elements. got=%d",
-			len(result.Elements))
+			len(els))
 	}
 
-	testIntegerObject(t, result.Elements[0], 1)
-	testIntegerObject(t, result.Elements[1], 4)
-	testIntegerObject(t, result.Elements[2], 6)
+	testIntegerObject(t, els[0], 1)
+	testIntegerObject(t, els[1], 4)
+	testIntegerObject(t, els[2], 6)
 }
 
 func TestArrayIndexExpressions(t *testing.T) {

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -196,7 +196,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		for i, r := range gorunes {
 			runes[i] = object.String{Value: string(r)}
 		}
-		return object.Array{Elements: runes}
+		return object.NewArray(runes)
 	}
 	err = object.CreateFunction(strFn)
 	if err != nil {
@@ -235,7 +235,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		for i, p := range parts {
 			strs[i] = object.String{Value: p}
 		}
-		return object.Array{Elements: strs}
+		return object.NewArray(strs)
 	}
 	err = object.CreateFunction(strFn)
 	if err != nil {
@@ -244,7 +244,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	strFn.Name = "join"
 	strFn.ArgTypes = []object.Type{object.ARRAY, object.STRING}
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
-		arr := args[0].(object.Array).Elements
+		arr := object.Elements(args[0])
 		sep := ""
 		if len(args) == 2 {
 			sep = args[1].(object.String).Value

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func Main() int {
 	noAuto := flag.Bool("no-auto", false, "don't auto load/save the state to ./.gr")
 	maxDepth := flag.Int("max-depth", eval.DefaultMaxDepth-1, "Maximum interpreter depth")
 	maxLen := flag.Int("max-save-len", 4000, "Maximum len of saved identifiers, use 0 for unlimited")
+	panicOk := flag.Bool("panic", false, "Don't catch panic - only for development/debugging")
 
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
@@ -92,6 +93,7 @@ func Main() int {
 		AutoSave:    !*noAuto,
 		MaxDepth:    *maxDepth + 1,
 		MaxValueLen: *maxLen,
+		PanicOk:     *panicOk,
 	}
 	if hookBefore != nil {
 		ret := hookBefore()

--- a/object/state.go
+++ b/object/state.go
@@ -54,24 +54,24 @@ func (e *Environment) BaseInfo() *Map {
 	for _, v := range sets.Sort(tokInfo.Keywords) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"keywords"}, Array{Elements: keys}) // 1
+	baseInfo.Set(String{"keywords"}, Array{elements: keys}) // 1
 	keys = make([]Object, 0, len(tokInfo.Tokens))
 	for _, v := range sets.Sort(tokInfo.Tokens) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"tokens"}, Array{Elements: keys}) // 2
+	baseInfo.Set(String{"tokens"}, Array{elements: keys}) // 2
 	keys = make([]Object, 0, len(tokInfo.Builtins))
 	for _, v := range sets.Sort(tokInfo.Builtins) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"builtins"}, Array{Elements: keys}) // 3
+	baseInfo.Set(String{"builtins"}, Array{elements: keys}) // 3
 	// Ditto cache this as it's set for a given environment.
 	ext := ExtraFunctions()
 	keys = make([]Object, 0, len(ext))
 	for k := range ext {
 		keys = append(keys, String{Value: k})
 	}
-	arr := Array{Elements: keys}
+	arr := Array{elements: keys}
 	sort.Sort(arr)
 	baseInfo.Set(String{"gofuncs"}, arr)                             // 4
 	baseInfo.Set(String{"version"}, String{Value: cli.ShortVersion}) // 5
@@ -94,7 +94,7 @@ func (e *Environment) Info() Object {
 		e = e.outer
 	}
 	info := e.BaseInfo()
-	info.Set(String{"all_ids"}, Array{Elements: allKeys}) // 7
+	info.Set(String{"all_ids"}, Array{elements: allKeys}) // 7
 	return info
 }
 


### PR DESCRIPTION
Also cleans up the code by making the internal object.Array Elements private.