### PR TITLE
Small maps

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -219,7 +219,7 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 }
 
 func (s *State) evalMapLiteral(node *ast.MapLiteral) object.Object {
-	result := object.NewMap()
+	result := object.NewMapSize(len(node.Order))
 
 	for _, keyNode := range node.Order {
 		valueNode := node.Pairs[keyNode]
@@ -229,9 +229,9 @@ func (s *State) evalMapLiteral(node *ast.MapLiteral) object.Object {
 			return object.Error{Value: "key " + key.Inspect() + " is not hashable"}
 		}
 		value := s.evalInternal(valueNode)
-		result.Set(key, value)
+		result = result.Set(key, value)
 	}
-	return &result
+	return result
 }
 
 func (s *State) evalPrintLogError(node *ast.Builtin) object.Object {
@@ -340,7 +340,7 @@ func evalIndexExpression(left, index object.Object) object.Object {
 }
 
 func evalMapIndexExpression(hash, key object.Object) object.Object {
-	m := hash.(*object.Map)
+	m := hash.(object.Map)
 	v, ok := m.Get(key)
 	if !ok {
 		return object.NULL
@@ -692,8 +692,8 @@ func evalArrayInfixExpression(operator token.Type, left, right object.Object) ob
 }
 
 func evalMapInfixExpression(operator token.Type, left, right object.Object) object.Object {
-	leftMap := left.(*object.Map)
-	rightMap := right.(*object.Map)
+	leftMap := left.(object.Map)
+	rightMap := right.(object.Map)
 	switch operator { //nolint:exhaustive // we have default.
 	case token.PLUS: // concat / append
 		return leftMap.Append(rightMap)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -580,7 +580,7 @@ func TestMapLiterals(t *testing.T) {
     }`
 
 	evaluated := testEval(t, input)
-	result, ok := evaluated.(*object.Map)
+	result, ok := evaluated.(object.Map)
 	if !ok {
 		t.Fatalf("Eval didn't return Map. got=%T (%+v)", evaluated, evaluated)
 	}
@@ -931,6 +931,20 @@ func TestMapAccidentalMutation(t *testing.T) {
 	resStr := res.Inspect()
 	expected := `{1:1,nil:"foo"}`
 	if resStr != expected {
-		t.Fatalf("wrong result, got %q expected %q", resStr, expected)
+		t.Errorf("wrong result, got %q expected %q", resStr, expected)
+	}
+}
+
+func TestSmallMapSorting(t *testing.T) {
+	inp := `m={2:"b"};n={1:"a"};m+n`
+	expected := `{1:"a",2:"b"}`
+	s := eval.NewState()
+	res, err := eval.EvalString(s, inp, false)
+	if err != nil {
+		t.Errorf("should not have errored: %v", err)
+	}
+	resStr := res.Inspect()
+	if resStr != expected {
+		t.Errorf("wrong result, got %q expected %q", resStr, expected)
 	}
 }

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -416,15 +416,9 @@ func saveFunc(env any, _ string, args []object.Object) object.Object {
 		return object.Error{Value: err.Error()}
 	}
 	log.Infof("Saved %d ids/fns to: %s", n, file)
-	res := &object.Map{}
-	res.Set(
-		object.String{Value: "entries"},
-		object.Integer{Value: int64(n)})
-	res.Set(
-		object.String{Value: "filename"},
-		object.String{Value: file},
-	)
-	return res
+	return object.MakeQuad(
+		object.String{Value: "entries"}, object.Integer{Value: int64(n)},
+		object.String{Value: "filename"}, object.String{Value: file})
 }
 
 func loadFunc(env any, _ string, args []object.Object) object.Object {

--- a/object/object.go
+++ b/object/object.go
@@ -175,33 +175,6 @@ func Cmp(ei, ej Object) int {
 	return 1
 }
 
-func ArrayEquals(left, right []Object) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for i, l := range left {
-		if !Equals(l, right[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func MapEquals(left, right *BigMap) bool {
-	if len(left.kv) != len(right.kv) {
-		return false
-	}
-	for i, kv := range left.kv {
-		if !Equals(kv.Key, right.kv[i].Key) {
-			return false
-		}
-		if !Equals(kv.Value, right.kv[i].Value) {
-			return false
-		}
-	}
-	return true
-}
-
 func CompareKeys(a, b keyValuePair) int {
 	return Cmp(a.Key, b.Key)
 }

--- a/object/object.go
+++ b/object/object.go
@@ -293,9 +293,7 @@ func (m SmallMap) Rest() Object {
 		return NULL
 	}
 	res := SmallMap{len: m.len - 1}
-	for i := 1; i < m.len; i++ {
-		res.smallKV[i-1] = keyValuePair{m.smallKV[i].Key, m.smallKV[i].Value}
-	}
+	copy(res.smallKV[:m.len-1], m.smallKV[1:m.len])
 	return res
 }
 

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -16,7 +16,7 @@ func TestStringMapKey(t *testing.T) {
 	}
 
 	m := object.NewMap()
-	m.Set(hello1, diff1)
+	m = m.Set(hello1, diff1)
 
 	v, ok := m.Get(hello2)
 	if !ok {

--- a/object/state.go
+++ b/object/state.go
@@ -54,24 +54,24 @@ func (e *Environment) BaseInfo() *BigMap {
 	for _, v := range sets.Sort(tokInfo.Keywords) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"keywords"}, Array{elements: keys}) // 1
+	baseInfo.Set(String{"keywords"}, BigArray{elements: keys}) // 1
 	keys = make([]Object, 0, len(tokInfo.Tokens))
 	for _, v := range sets.Sort(tokInfo.Tokens) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"tokens"}, Array{elements: keys}) // 2
+	baseInfo.Set(String{"tokens"}, BigArray{elements: keys}) // 2
 	keys = make([]Object, 0, len(tokInfo.Builtins))
 	for _, v := range sets.Sort(tokInfo.Builtins) {
 		keys = append(keys, String{Value: v})
 	}
-	baseInfo.Set(String{"builtins"}, Array{elements: keys}) // 3
+	baseInfo.Set(String{"builtins"}, BigArray{elements: keys}) // 3
 	// Ditto cache this as it's set for a given environment.
 	ext := ExtraFunctions()
 	keys = make([]Object, 0, len(ext))
 	for k := range ext {
 		keys = append(keys, String{Value: k})
 	}
-	arr := Array{elements: keys}
+	arr := BigArray{elements: keys}
 	sort.Sort(arr)
 	baseInfo.Set(String{"gofuncs"}, arr)                             // 4
 	baseInfo.Set(String{"version"}, String{Value: cli.ShortVersion}) // 5
@@ -94,7 +94,7 @@ func (e *Environment) Info() Object {
 		e = e.outer
 	}
 	info := e.BaseInfo()
-	info.Set(String{"all_ids"}, Array{elements: allKeys}) // 7
+	info.Set(String{"all_ids"}, BigArray{elements: allKeys}) // 7
 	return info
 }
 

--- a/object/state.go
+++ b/object/state.go
@@ -42,13 +42,13 @@ func (e *Environment) Len() int {
 	return len(e.store)
 }
 
-var baseInfo Map
+var baseInfo BigMap
 
-func (e *Environment) BaseInfo() *Map {
+func (e *Environment) BaseInfo() *BigMap {
 	if baseInfo.kv != nil {
 		return &baseInfo
 	}
-	baseInfo.kv = make([]KV, 0, 7) // 6 here + all_ids
+	baseInfo.kv = make([]keyValuePair, 0, 7) // 6 here + all_ids
 	tokInfo := token.Info()
 	keys := make([]Object, 0, len(tokInfo.Keywords))
 	for _, v := range sets.Sort(tokInfo.Keywords) {
@@ -82,8 +82,8 @@ func (e *Environment) BaseInfo() *Map {
 func (e *Environment) Info() Object {
 	allKeys := make([]Object, e.depth+1)
 	for {
-		val := &Map{}
-		val.kv = make([]KV, 0, e.Len())
+		val := &BigMap{}
+		val.kv = make([]keyValuePair, 0, e.Len())
 		for k, v := range e.store {
 			val.Set(String{Value: k}, v)
 		}


### PR DESCRIPTION
Similar to #163 

So small maps (up to 4 keys) can be cached at expense of copying


Renamed the previous object.Map -> object.BigMap
Made a Map interface (called MapInterface during development and back to using Map now after checking references to BigMap etc)
