### PR TITLE
Index range expression, including right relative to the end for both direct access and ranges

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -282,7 +282,11 @@ func (i InfixExpression) PrettyPrint(out *PrintState) *PrintState {
 	} else {
 		out.Print(" ", i.Literal(), " ")
 	}
-	i.Right.PrettyPrint(out)
+	if i.Right == nil {
+		out.Print("nil")
+	} else {
+		i.Right.PrettyPrint(out)
+	}
 	if !isAssign {
 		out.ExpressionLevel--
 	}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -321,14 +321,12 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 func (s *State) evalIndexRangeExpression(node *ast.IndexExpression, left object.Object) object.Object {
 	e := node.Index.(*ast.InfixExpression)
 	leftIndex := s.evalInternal(e.Left)
+	nilRight := (e.Right == nil)
 	var rightIndex object.Object
-	if e.Right != nil {
-		rightIndex = s.evalInternal(e.Right)
-	}
-	nilRight := rightIndex == nil
 	if nilRight {
 		log.Debugf("eval index %s[%s:]", left.Inspect(), leftIndex.Inspect())
 	} else {
+		rightIndex = s.evalInternal(e.Right)
 		log.Debugf("eval index %s[%s:%s]", left.Inspect(), leftIndex.Inspect(), rightIndex.Inspect())
 	}
 	if leftIndex.Type() != object.INTEGER || (!nilRight && rightIndex.Type() != object.INTEGER) {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -553,6 +553,10 @@ func TestArrayIndexExpressions(t *testing.T) {
 		},
 		{
 			"[1, 2, 3][-1]",
+			3,
+		},
+		{
+			"[1, 2, 3][-4]",
 			nil,
 		},
 	}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -559,6 +559,10 @@ func TestArrayIndexExpressions(t *testing.T) {
 			"[1, 2, 3][-4]",
 			nil,
 		},
+		{
+			"len([1, 2, 3, 4][2:])",
+			2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/boxed_text.gr
+++ b/examples/boxed_text.gr
@@ -81,16 +81,9 @@ func for(n, f, start) {
     l(1,f,start)
 }
 
-func generateIndices(n) {
-	result = []
-	for(n, func(i, result) {
-		return result + [i-1]
-	},[])
-}
-
 func maxWidths(widths) {
     cols = len(widths[0])
-    colIndices = generateIndices(cols) // Generates [0, 1, 2] for 3 columns
+    colIndices = 0:cols // Generates [0, 1, 2] for 3 columns
 
     return apply(func(colIndex) {
         return max(apply(func(row) {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -196,6 +196,13 @@ stderr '@'
 grol -quiet -panic -c 'keys(info.all_ids[0])'
 !stderr panic
 
+# range
+grol -quiet -c '(23:31)[4:]'
+stdout '^\[27,28,29,30\]$'
+
+# range
+grol -quiet -c '(23:31)[5-1:23-24]'
+stdout '^\[27,28,29\]$'
 
 -- sample_test.gr --
 // Sample file that our gorepl can interpret

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -447,6 +447,10 @@ func (p *Parser) parseInfixExpression(left ast.Node) ast.Node {
 	expression.Token = p.curToken
 
 	precedence := p.curPrecedence()
+	// handle [n:] case
+	if (expression.Token.Type() == token.COLON) && (p.peekToken.Type() == token.RBRACKET) {
+		return expression
+	}
 	p.nextToken()
 	expression.Right = p.parseExpression(precedence)
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -365,7 +365,10 @@ func TestIncompleteBlockComment(t *testing.T) {
 	}
 }
 
-func TestNilToken(t *testing.T) {
+func TestInvalidToken(t *testing.T) {
+	// This turns into the invalid token which in turn can't be found in prefix map,
+	// it used to crash in earlier versions, this is the regression for that crash.
+	// it also checks the error message in first line + first column case.
 	inp := "@"
 	l := lexer.New(inp)
 	p := parser.New(l)

--- a/token/token.go
+++ b/token/token.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"fortio.org/log"
 	"fortio.org/sets"
 )
 
@@ -315,10 +314,6 @@ func ByType(t Type) *Token {
 }
 
 func (t *Token) Literal() string {
-	if t == nil {
-		log.Critf("Nil token .Literal() called")
-		return "NIL_TOKEN"
-	}
 	return t.literal
 }
 


### PR DESCRIPTION
```go
$ "ABCDEF"[2:-1]
"CDE"

$ 12:16
[12,13,14,15]

$ (12:16)[2:] 
[14,15]

```
working for now (and maps not broken) - did extra work getting `slice[42:]` to work


bonus:
```go
$ -42:-37
[-42,-41,-40,-39,-38]
$ [1,2,3,4,5][-1]
5
$ [1,2,3,4,5][-2:-1]
[4]
// ^ may look odd but consistent with
$ [1,2,3,4,5][1]    
2
$ [1,2,3,4,5][0:1]
[1]
```