### PR TITLE
Unwrap() no panic even with map of unhashable keys and option to force map keys to be strings, adding json_go with optional indent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: generate lint check test run
 
-GO_BUILD_TAGS:=no_net,no_json,no_pprof
+GO_BUILD_TAGS:=no_net,no_pprof
 
 run: grol
 	# Interactive debug run: use logger with file and line numbers

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -77,7 +77,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 		return object.Error{Value: "identifier not found: " + id}
 	}
 	var toAdd int64
-	switch node.Type() { //nolint:exhaustive // we have default.
+	switch node.Type() {
 	case token.INCR:
 		toAdd = 1
 	case token.DECR:
@@ -117,7 +117,7 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 		return s.evalIdentifier(node)
 	case *ast.PrefixExpression:
 		log.LogVf("eval prefix %s", node.DebugString())
-		switch node.Type() { //nolint:exhaustive // we have default.
+		switch node.Type() {
 		case token.INCR, token.DECR:
 			return s.evalPrefixIncrDecr(node.Type(), node.Right)
 		default:
@@ -306,7 +306,7 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 			return val
 		}
 	}
-	switch t { //nolint:exhaustive // we have defaults and covering all the builtins.
+	switch t {
 	case token.ERROR, token.PRINT, token.PRINTLN, token.LOG:
 		return s.evalPrintLogError(node)
 	case token.FIRST:
@@ -625,7 +625,7 @@ func (s *State) evalStatements(stmts []ast.Node) object.Object {
 }
 
 func (s *State) evalPrefixExpression(operator token.Type, right object.Object) object.Object {
-	switch operator { //nolint:exhaustive // we have default.
+	switch operator {
 	case token.BLOCKCOMMENT:
 		// /* comment */ treated as identity operator. TODO: implement in parser.
 		return right
@@ -660,7 +660,7 @@ func (s *State) evalBangOperatorExpression(right object.Object) object.Object {
 }
 
 func (s *State) evalMinusPrefixOperatorExpression(right object.Object) object.Object {
-	switch right.Type() { //nolint:exhaustive // we have default which is errors.
+	switch right.Type() {
 	case object.INTEGER:
 		value := right.(object.Integer).Value
 		return object.Integer{Value: -value}
@@ -725,7 +725,7 @@ func evalStringInfixExpression(operator token.Type, left, right object.Object) o
 
 func evalArrayInfixExpression(operator token.Type, left, right object.Object) object.Object {
 	leftVal := object.Elements(left)
-	switch operator { //nolint:exhaustive // we have default.
+	switch operator {
 	case token.ASTERISK: // repeat
 		if right.Type() != object.INTEGER {
 			return object.Error{Value: "right operand of * on arrays must be an integer"}
@@ -756,7 +756,7 @@ func evalArrayInfixExpression(operator token.Type, left, right object.Object) ob
 func evalMapInfixExpression(operator token.Type, left, right object.Object) object.Object {
 	leftMap := left.(object.Map)
 	rightMap := right.(object.Map)
-	switch operator { //nolint:exhaustive // we have default.
+	switch operator {
 	case token.PLUS: // concat / append
 		return leftMap.Append(rightMap)
 	default:
@@ -773,7 +773,7 @@ func evalIntegerInfixExpression(operator token.Type, left, right object.Object) 
 	leftVal := left.(object.Integer).Value
 	rightVal := right.(object.Integer).Value
 
-	switch operator { //nolint:exhaustive // we have default.
+	switch operator {
 	case token.PLUS:
 		return object.Integer{Value: leftVal + rightVal}
 	case token.MINUS:
@@ -810,7 +810,7 @@ func evalIntegerInfixExpression(operator token.Type, left, right object.Object) 
 }
 
 func getFloatValue(o object.Object) (float64, *object.Error) {
-	switch o.Type() { //nolint:exhaustive // we handle the others in default.
+	switch o.Type() {
 	case object.INTEGER:
 		return float64(o.(object.Integer).Value), nil
 	case object.FLOAT:
@@ -830,7 +830,7 @@ func evalFloatInfixExpression(operator token.Type, left, right object.Object) ob
 	if oerr != nil {
 		return *oerr
 	}
-	switch operator { //nolint:exhaustive // we have default.
+	switch operator {
 	case token.PLUS:
 		return object.Float{Value: leftVal + rightVal}
 	case token.MINUS:

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -326,7 +326,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		ArgTypes: []object.Type{object.ANY},
 		Callback: func(_ any, _ string, args []object.Object) object.Object {
 			o := args[0]
-			switch o.Type() { //nolint:exhaustive // that's what default is for.
+			switch o.Type() {
 			case object.INTEGER:
 				return o
 			case object.NIL:

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -138,22 +138,22 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	object.AddIdentifier("PI", object.Float{Value: math.Pi})
 	object.AddIdentifier("E", object.Float{Value: math.E}) // using uppercase so "e" isn't taken/shadowed.
 	jsonFn := object.Extension{
-		Name:     "json_go",
+		Name:     "json",
 		MinArgs:  1,
 		MaxArgs:  1,
 		ArgTypes: []object.Type{object.ANY},
-		Callback: object.ShortCallback(jsonSerGo),
+		Callback: object.ShortCallback(jsonSer),
 	}
 	err = object.CreateFunction(jsonFn)
 	if err != nil {
 		return err
 	}
 	jsonFn = object.Extension{
-		Name:     "json",
+		Name:     "json_go",
 		MinArgs:  1,
-		MaxArgs:  1,
-		ArgTypes: []object.Type{object.ANY},
-		Callback: object.ShortCallback(jsonSer),
+		MaxArgs:  2,
+		ArgTypes: []object.Type{object.ANY, object.STRING},
+		Callback: object.ShortCallback(jsonSerGo),
 	}
 	err = object.CreateFunction(jsonFn)
 	if err != nil {
@@ -381,7 +381,13 @@ func jsonSer(args []object.Object) object.Object {
 
 func jsonSerGo(args []object.Object) object.Object {
 	v := args[0].Unwrap(true)
-	bytes, err := json.Marshal(v)
+	var err error
+	var bytes []byte
+	if len(args) == 1 {
+		bytes, err = json.Marshal(v)
+	} else {
+		bytes, err = json.MarshalIndent(v, "", args[1].(object.String).Value)
+	}
 	if err != nil {
 		return object.Error{Value: err.Error()}
 	}

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -235,6 +235,14 @@ stderr 'Incomplete input'
 grol -quiet -c '(()=>1)()'
 stdout '^1$'
 
+# no crash on map unwraps
+grol -quiet -c 'printf("%v\n", {"abc":42,"def":62, "x": {[3]:122, true:false} })'
+stdout '^map\[abc:42 def:62 x:map\[\[3\]:122 true:false\]\]$'
+
+# json despite non string keys
+grol -quiet -c 'println(json_go({"abc":42, 63:63, "x": {[3]:122, true:false} }))'
+stdout '^{"63":63,"abc":42,"x":{"\[3\]":122,"true":false}}$'
+
 -- sample_test.gr --
 // Sample file that our gorepl can interpret
 // <--- comments

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -243,6 +243,19 @@ stdout '^map\[abc:42 def:62 x:map\[\[3\]:122 true:false\]\]$'
 grol -quiet -c 'println(json_go({"abc":42, 63:63, "x": {[3]:122, true:false} }))'
 stdout '^{"63":63,"abc":42,"x":{"\[3\]":122,"true":false}}$'
 
+# pretty print variant
+grol -quiet -c 'println(json_go({"abc":42, 63:63, "x": {[3]:122, true:false} }, "  "))'
+cmp stdout json_output
+
+-- json_output --
+{
+  "63": 63,
+  "abc": 42,
+  "x": {
+    "[3]": 122,
+    "true": false
+  }
+}
 -- sample_test.gr --
 // Sample file that our gorepl can interpret
 // <--- comments

--- a/object/interp.go
+++ b/object/interp.go
@@ -76,10 +76,10 @@ func initialIdentifiersCopy() map[string]Object {
 	return copied
 }
 
-func Unwrap(objs []Object) []any {
+func Unwrap(objs []Object, forceStringKeys bool) []any {
 	res := make([]any, len(objs))
 	for i, o := range objs {
-		res[i] = o.Unwrap()
+		res[i] = o.Unwrap(forceStringKeys)
 	}
 	return res
 }

--- a/object/object.go
+++ b/object/object.go
@@ -83,7 +83,7 @@ func Hashable(o Object) bool {
 }
 
 func UnwrapHashable(o Object) any {
-	switch o.Type() { //nolint:exhaustive // getting a bit tired of this linter, why does it trigger when you have a default?
+	switch o.Type() {
 	case INTEGER, FLOAT, BOOLEAN, NIL, ERROR, STRING:
 		return o.Unwrap(false)
 	default:


### PR DESCRIPTION
we could build tag the encoding/json, it adds 152k
```
├─────────┬──────────────────────────┬──────────┬──────────┬─────────┤
│ PERCENT │ NAME                     │ OLD SIZE │ NEW SIZE │ DIFF    │
├─────────┼──────────────────────────┼──────────┼──────────┼─────────┤
│ +100%   │ encoding/json            │          │ 83 kB    │ +83 kB  │
│ +64.94% │ slices                   │ 19 kB    │ 32 kB    │ +13 kB  │
│ +7.66%  │ reflect                  │ 66 kB    │ 71 kB    │ +5.1 kB │
│ +16.46% │ sync                     │ 22 kB    │ 25 kB    │ +3.6 kB │
[...]
│ +6.44%  │ grol                     │ 2.4 MB   │ 2.5 MB   │ +152 kB │
```

```go
println(json_go({"abc":42, 63:63, "x": {[3]:122, true:false} }, "  "))
```
```json
{
  "63": 63,
  "abc": 42,
  "x": {
    "[3]": 122,
    "true": false
  }
}
```