### PR TITLE
Bug with map returned from lamba single arg, missing outer braces that are needed

### DIFF
--- a/main_test.txtar
+++ b/main_test.txtar
@@ -249,7 +249,7 @@ cmp stdout json_output
 
 # returning a map in lambda shouldn't lose needed extra {} despite being solo argument
 grol -quiet -c '()=>{{"a":1,"b":2}}'
-stdout '^()=>{{"a":1,"b":2}}$'
+stdout '^\(\)=>{{"a":1,"b":2}}$'
 
 -- json_output --
 {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -247,6 +247,10 @@ stdout '^{"63":63,"abc":42,"x":{"\[3\]":122,"true":false}}$'
 grol -quiet -c 'println(json_go({"abc":42, 63:63, "x": {[3]:122, true:false} }, "  "))'
 cmp stdout json_output
 
+# returning a map in lambda shouldn't lose needed extra {} despite being solo argument
+grol -quiet -c '()=>{{"a":1,"b":2}}'
+stdout '^()=>{{"a":1,"b":2}}$'
+
 -- json_output --
 {
   "63": 63,

--- a/object/object.go
+++ b/object/object.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"grol.io/grol/ast"
+	"grol.io/grol/token"
 )
 
 type Type uint8
@@ -535,11 +536,12 @@ func (f *Function) lambdaPrint(ps *ast.PrintState, out *strings.Builder) string 
 	} else {
 		out.WriteString("=>")
 	}
-	if len(f.Body.Statements) != 1 {
+	needBraces := len(f.Body.Statements) != 1 || f.Body.Statements[0].Value().Type() == token.LBRACE
+	if needBraces {
 		out.WriteString("{")
 	}
 	f.Body.PrettyPrint(ps)
-	if len(f.Body.Statements) != 1 {
+	if needBraces {
 		out.WriteString("}")
 	}
 	return out.String()


### PR DESCRIPTION
Started as a more complex one in discord bot but reduced to :

```
$ ()=>{{"a":1,"b":2}}
()=>{"a":1,"b":2}
```
which doesn't work when reloaded:
```
parser error: no prefix parse function for `,` found:
()=>{"a":1,"b":2}
          ^
```

- [x] test failing
- [x] fix
