### PR TITLE
Optional ClientData and Help for extensions, PreInput hook so per interp client data can be set, expose Extensions

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -456,6 +456,9 @@ func (s *State) applyExtension(fn object.Extension, args []object.Object) object
 				arg.Type(), fn.Inspect())}
 		}
 	}
+	if fn.ClientData != nil {
+		return fn.Callback(fn.ClientData, fn.Name, args)
+	}
 	return fn.Callback(s, fn.Name, args)
 }
 
@@ -581,7 +584,7 @@ func (s *State) evalIdentifier(node *ast.Identifier) object.Object {
 	if ok {
 		return val
 	}
-	val, ok = s.extensions[node.Literal()]
+	val, ok = s.Extensions[node.Literal()]
 	if !ok {
 		return object.Error{Value: "identifier not found: " + node.Literal()}
 	}

--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -22,7 +22,7 @@ type State struct {
 	macroState *object.Environment
 	env        *object.Environment
 	cache      Cache
-	extensions map[string]object.Extension
+	Extensions map[string]object.Extension
 	NoLog      bool // turn log() into println() (for EvalString)
 	// Max depth / recursion level - default DefaultMaxDepth,
 	// note that a simple function consumes at least 2 levels and typically at least 3 or 4.
@@ -38,7 +38,7 @@ func NewState() *State {
 		Out:        os.Stdout,
 		LogOut:     os.Stdout,
 		cache:      NewCache(),
-		extensions: object.ExtraFunctions(),
+		Extensions: object.ExtraFunctions(),
 		macroState: object.NewMacroEnvironment(),
 		MaxDepth:   DefaultMaxDepth,
 		depth:      0,
@@ -51,7 +51,7 @@ func NewBlankState() *State {
 		Out:        io.Discard,
 		LogOut:     io.Discard,
 		cache:      NewCache(),
-		extensions: make(map[string]object.Extension),
+		Extensions: make(map[string]object.Extension),
 		macroState: object.NewMacroEnvironment(),
 		MaxDepth:   DefaultMaxDepth,
 	}

--- a/examples/short_lambdas.gr
+++ b/examples/short_lambdas.gr
@@ -1,0 +1,9 @@
+
+// smallest
+println("No arg lambda, expecting 1:", (()=>1)())
+
+// 1 arg
+println("One arg lambda expecting 1:", (x=>1)(2))
+
+// varargs
+println("Variable args lambda expecting 3:", (..=>len(..))(2,3,4))

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -154,11 +154,13 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		MaxArgs:  2,
 		ArgTypes: []object.Type{object.ANY, object.STRING},
 		Callback: object.ShortCallback(jsonSerGo),
+		Help:     `optional indent e.g json_go(m, "  ")`,
 	}
 	err = object.CreateFunction(jsonFn)
 	if err != nil {
 		return err
 	}
+	jsonFn.Help = ""
 	jsonFn.Name = "eval"
 	jsonFn.Callback = evalFunc
 	jsonFn.ArgTypes = []object.Type{object.STRING}
@@ -176,6 +178,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		MinArgs:  0, // empty only case - ie ".gr" save file.
 		MaxArgs:  1,
 		ArgTypes: []object.Type{object.STRING},
+		Help:     "filename (.gr)",
 	}
 	if c.HasSave {
 		loadSaveFn.Name = "save"

--- a/object/interp.go
+++ b/object/interp.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"errors"
-	"maps"
 )
 
 var (
@@ -44,7 +43,7 @@ func CreateFunction(cmd Extension) error {
 // Returns a copy of the table of extended functions.
 // (so multiple interpreters in a process have their own copy that can have ClientData mutated).
 func ExtraFunctions() map[string]Extension {
-	return maps.Clone(extraFunctions)
+	return extraFunctions // no need to make a copy as each value need to be set to be changed (map of structs, not pointers).
 }
 
 // Add values to top level environment, e.g "pi" -> 3.14159...

--- a/object/interp.go
+++ b/object/interp.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"errors"
+	"maps"
 )
 
 var (
@@ -40,8 +41,10 @@ func CreateFunction(cmd Extension) error {
 	return nil
 }
 
+// Returns a copy of the table of extended functions.
+// (so multiple interpreters in a process have their own copy that can have ClientData mutated).
 func ExtraFunctions() map[string]Extension {
-	return extraFunctions
+	return maps.Clone(extraFunctions)
 }
 
 // Add values to top level environment, e.g "pi" -> 3.14159...

--- a/object/interp.go
+++ b/object/interp.go
@@ -40,8 +40,7 @@ func CreateFunction(cmd Extension) error {
 	return nil
 }
 
-// Returns a copy of the table of extended functions.
-// (so multiple interpreters in a process have their own copy that can have ClientData mutated).
+// Returns the table of extended functions to seed the state of an eval.
 func ExtraFunctions() map[string]Extension {
 	return extraFunctions // no need to make a copy as each value need to be set to be changed (map of structs, not pointers).
 }

--- a/object/object.go
+++ b/object/object.go
@@ -978,12 +978,14 @@ func (m Macro) JSON(w io.Writer) error {
 
 // Extensions are functions implemented in go and exposed to grol.
 type Extension struct {
-	Name     string      // Name to make the function available as in grol.
-	MinArgs  int         // Minimum number of arguments required.
-	MaxArgs  int         // Maximum number of arguments allowed. -1 for unlimited.
-	ArgTypes []Type      // Type of each argument, provided at least up to MinArgs.
-	Callback ExtFunction // The go function or lambda to call when the grol by Name(...) is invoked.
-	Variadic bool        // MaxArgs > MinArgs (or MaxArg == -1)
+	Name       string      // Name to make the function available as in grol.
+	MinArgs    int         // Minimum number of arguments required.
+	MaxArgs    int         // Maximum number of arguments allowed. -1 for unlimited.
+	ArgTypes   []Type      // Type of each argument, provided at least up to MinArgs.
+	Callback   ExtFunction // The go function or lambda to call when the grol by Name(...) is invoked.
+	Variadic   bool        // MaxArgs > MinArgs (or MaxArg == -1)
+	ClientData any         // Opaque data that the extension can use instead of the global state.
+	Help       string      // Help text for the function.
 }
 
 // Adapter for functions that only need the argumants.
@@ -1039,6 +1041,10 @@ func (e Extension) Inspect() string {
 	out.WriteString("(")
 	e.Usage(&out)
 	out.WriteString(")")
+	if e.Help != "" {
+		out.WriteString(" // ")
+		out.WriteString(e.Help)
+	}
 	return out.String()
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -982,10 +982,10 @@ type Extension struct {
 	MinArgs    int         // Minimum number of arguments required.
 	MaxArgs    int         // Maximum number of arguments allowed. -1 for unlimited.
 	ArgTypes   []Type      // Type of each argument, provided at least up to MinArgs.
+	Help       string      // Help text for the function. Appended as a comment when printing the function.
 	Callback   ExtFunction // The go function or lambda to call when the grol by Name(...) is invoked.
+	ClientData any         // Opaque data that will be passed as first argument of Callback if set (state is, if nil).
 	Variadic   bool        // MaxArgs > MinArgs (or MaxArg == -1)
-	ClientData any         // Opaque data that the extension can use instead of the global state.
-	Help       string      // Help text for the function.
 }
 
 // Adapter for functions that only need the argumants.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -146,20 +146,25 @@ func EvalAll(s *eval.State, in io.Reader, out io.Writer, options Options) []stri
 	return errs
 }
 
+// EvalStringOptions returns the default options needed for EvalString.
+func EvalStringOptions() Options {
+	return Options{All: true, ShowEval: true, NoColor: true}
+}
+
 // EvalString can be used from playground etc for single eval.
 // returns the eval errors and an array of errors if any.
 // also returns the normalized/reformatted input if no parsing errors
 // occurred.
 // Default options are Options{All: true, ShowEval: true, NoColor: true, Compact: CompactEvalString}.
 func EvalString(what string) (string, []string, string) {
-	return EvalStringWithOption(Options{All: true, ShowEval: true, NoColor: true, Compact: false}, what)
+	return EvalStringWithOption(EvalStringOptions(), what)
 }
 
 // EvalStringWithOption can be used from playground etc for single eval.
 // returns the eval errors and an array of errors if any.
 // also returns the normalized/reformatted input if no parsing errors
 // occurred.
-// Following options should be set (like in EvalString) to control the behavior:
+// Following options should be set (like in EvalString/EvalStringOptions) to control the behavior:
 //
 //	All: true. ShowEval: true, NoColor: true.
 //

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -156,7 +156,7 @@ func EvalStringOptions() Options {
 // returns the eval errors and an array of errors if any.
 // also returns the normalized/reformatted input if no parsing errors
 // occurred.
-// Default options are Options{All: true, ShowEval: true, NoColor: true, Compact: CompactEvalString}.
+// Default options are EvalStringOptions()'s.
 func EvalString(what string) (string, []string, string) {
 	return EvalStringWithOption(EvalStringOptions(), what)
 }
@@ -165,11 +165,9 @@ func EvalString(what string) (string, []string, string) {
 // returns the eval errors and an array of errors if any.
 // also returns the normalized/reformatted input if no parsing errors
 // occurred.
-// Following options should be set (like in EvalString/EvalStringOptions) to control the behavior:
-//
-//	All: true. ShowEval: true, NoColor: true.
-//
-// Options to set AutoLoad and AutoSave and Compact.
+// Following options should be set (starting from EvalStringOptions()) to
+// additionally control the behavior:
+// AutoLoad, AutoSave, Compact.
 func EvalStringWithOption(o Options, what string) (res string, errs []string, formatted string) {
 	s := eval.NewState()
 	if o.MaxDepth > 0 {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -44,18 +44,19 @@ func logParserErrors(p *parser.Parser) bool {
 const AutoSaveFile = extensions.GrolFileExtension
 
 type Options struct {
-	ShowParse   bool
-	ShowEval    bool
-	All         bool
-	NoColor     bool // color controlled by log package, unless this is set to true.
-	FormatOnly  bool
-	Compact     bool
-	DualFormat  bool // Want both non Compact (Compact=false) printed yet compact version returned by EvalOne for history.
-	NilAndErr   bool // Show nil and errors in normal output.
+	ShowParse  bool // Whether to show the result of the parsing phase (formatting of which depends on Compact).
+	ShowEval   bool // Whether to show the result of the evaluation phase (needed for EvalString to be useful and report errors).
+	All        bool // Whether the input might be an incomplete line (line mode vs all mode).
+	NoColor    bool // Unless this forces it off, color mode is controlled by the logger (depends on stderr being a terminal or not).
+	FormatOnly bool // Don't eval, just format the input.
+	Compact    bool // Compact mode for formatting.
+	DualFormat bool // Want both non Compact (Compact=false) printed yet compact version returned by EvalOne for history.
+	NilAndErr  bool // Show nil and errors in normal output (otherwise nil eval is ignored and errors are returned separately).
+	// Which filename to use for history, empty means no history load/save.
 	HistoryFile string
-	MaxHistory  int
-	AutoLoad    bool
-	AutoSave    bool
+	MaxHistory  int  // Maximum number of history lines to keep. 0 also disables history saving/loading (but not in memory history).
+	AutoLoad    bool // Autoload the .gr state file before eval or repl loop.
+	AutoSave    bool // Autosave the .gr state file at the end of successful eval or exit of repl loop.
 	MaxDepth    int  // Max depth of recursion, 0 is keeping the default (eval.DefaultMaxDepth).
 	MaxValueLen int  // Maximum len of a value when using save()/autosaving, 0 is unlimited.
 	PanicOk     bool // If true, panics are not caught (only for debugging/developing).

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -163,7 +163,7 @@ func TestPreInputHook(t *testing.T) {
 					intVal := cdata.(int64)
 					return &object.Integer{Value: intVal}
 				},
-				ClientData: int64(43),
+				ClientData: int64(42),
 			}
 		},
 	}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -151,21 +151,17 @@ func TestEvalStringPrintNoNil(t *testing.T) {
 }
 
 func TestPreInputHook(t *testing.T) {
-	opts := repl.Options{
-		All:      true,
-		ShowEval: true,
-		NoColor:  true,
-		PanicOk:  true,
-		PreInput: func(s *eval.State) {
-			s.Extensions["testHook"] = object.Extension{
-				Name: "testHook",
-				Callback: func(cdata any, _ string, _ []object.Object) object.Object {
-					intVal := cdata.(int64)
-					return &object.Integer{Value: intVal}
-				},
-				ClientData: int64(42),
-			}
-		},
+	opts := repl.EvalStringOptions()
+	opts.PanicOk = true
+	opts.PreInput = func(s *eval.State) {
+		s.Extensions["testHook"] = object.Extension{
+			Name: "testHook",
+			Callback: func(cdata any, _ string, _ []object.Object) object.Object {
+				intVal := cdata.(int64)
+				return &object.Integer{Value: intVal}
+			},
+			ClientData: int64(42),
+		}
 	}
 	inp := `testHook()`
 	expected := "42\n"

--- a/wasm/wasm_main.go
+++ b/wasm/wasm_main.go
@@ -37,16 +37,16 @@ func jsEval(this js.Value, args []js.Value) interface{} {
 	if len(args) == 2 {
 		compact = args[1].Bool()
 	}
-	res, errs, formatted := repl.EvalStringWithOption(
-		// For tinygo until recover is implemented, we would set a large value for MaxDepth to get
-		// Error: Maximum call stack size exceeded.
-		// instead of failing to handle our panic (!)
-		// https://tinygo.org/docs/reference/lang-support/#recover-builtin
-		// But enough is enough... switched back to big go for now, way too many troubles with tinygo as well
-		// as not exactly responsive to PRs nor issues folks (everyone trying their best yet...).
-		repl.Options{All: true, ShowEval: true, NoColor: true, Compact: compact, MaxDepth: WasmMaxDepth},
-		input,
-	)
+	opts := repl.EvalStringOptions()
+	opts.Compact = compact
+	// For tinygo until recover is implemented, we would set a large value for MaxDepth to get
+	// Error: Maximum call stack size exceeded.
+	// instead of failing to handle our panic (!)
+	// https://tinygo.org/docs/reference/lang-support/#recover-builtin
+	// But enough is enough... switched back to big go for now, way too many troubles with tinygo as well
+	// as not exactly responsive to PRs nor issues folks (everyone trying their best yet...).
+	opts.MaxDepth = WasmMaxDepth
+	res, errs, formatted := repl.EvalStringWithOption(opts, input)
 	result := make(map[string]any)
 	result["result"] = strings.TrimSuffix(res, "\n")
 	// transfer errors to []any (!)


### PR DESCRIPTION
Needed (https://github.com/grol-io/grol-discord-bot/pull/83 which 'tests' this) to make grol discord bot safer for sending complex messages where the channelID is attached to the ClientData and thus can't be modified by grol code

Extensions can be changed/set using now exposed Extensions in the state.

Improves on extensions discoverable help; eg:

```go
$ json_go  
json_go(any, [string]) // optional indent e.g json_go(m, "  ")
$ save
save([string]) // filename (.gr)
```

Through optional Help field

And client data replaces the default eval.State first argument in CallBack

Also adding repl.EvalStringOptions() which has the necessary starting values for EvalStringWithOptions to function.