### PR TITLE
Fix parsing issue inside if conditions

### DIFF
--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -967,7 +967,7 @@ func TestCrashKeys(t *testing.T) {
 }
 
 func TestParenInIf(t *testing.T) {
-	inp := `x=1; y=1; if (x)==y {42}`
+	inp := `if (1+2)==3 {42}`
 	s := eval.NewState()
 	res, err := eval.EvalString(s, inp, false)
 	if err != nil {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -965,3 +965,18 @@ func TestCrashKeys(t *testing.T) {
 		t.Errorf("should not have errored: %v", err)
 	}
 }
+
+func TestParenInIf(t *testing.T) {
+	inp := `x=1; y=1; if (x)==y {42}`
+	s := eval.NewState()
+	res, err := eval.EvalString(s, inp, false)
+	if err != nil {
+		t.Fatalf("should not have errored: %v", err)
+	}
+	if res.Type() != object.INTEGER {
+		t.Fatalf("should have returned an integer, got %#v", res)
+	}
+	if res.Inspect() != "42" {
+		t.Errorf("wrong result, got %q", res.Inspect())
+	}
+}

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -251,6 +251,10 @@ cmp stdout json_output
 grol -quiet -c '()=>{{"a":1,"b":2}}'
 stdout '^\(\)=>{{"a":1,"b":2}}$'
 
+# if extra paren are needed (like for a[x] in the left part of if condition) it should still parse.
+grol -quiet -c '()=> if 1+2==3 {4}'
+stdout '^\(\)=>if \(1\+2\)==3\{4}$'
+
 -- json_output --
 {
   "63": 63,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -542,18 +542,8 @@ func (p *Parser) parseIfExpression() ast.Node {
 	expression := &ast.IfExpression{}
 	expression.Token = p.curToken
 
-	needCloseParen := false
-	if p.peekTokenIs(token.LPAREN) {
-		needCloseParen = true
-		p.nextToken()
-	}
-
 	p.nextToken()
 	expression.Condition = p.parseExpression(LOWEST)
-
-	if needCloseParen && !p.expectPeek(token.RPAREN) {
-		return nil
-	}
 
 	if !p.expectPeek(token.LBRACE) {
 		return nil


### PR DESCRIPTION
Hardcoding effect of open paren wasn't very good
- [x] added test
- [x] fix

Fix #179 

Of note we should rely simplify the expressions because

```go
if 1+2==3 {} 
```

doesn't need to be written
```go
if (1+2)==3 {}
```