### PR TITLE
Better short circuit upon errors, info.all_ids is array of array of ids instead of key value pairs. Output the line number as part of parsing errors; Stack trace on runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ flags:
   -eval
     	show eval results (default true)
   -format
-    	don't execute, just parse and re format the input
+    	don't execute, just parse and reformat the input
   -history file
     	history file to use (default "~/.grol_history")
   -max-depth int

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -186,6 +186,9 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 		}
 		// Humans expect left to right evaluations.
 		left := s.Eval(node.Left)
+		if left.Type() == object.ERROR {
+			return left
+		}
 		// Short circuiting for AND and OR:
 		if node.Token.Type() == token.AND && left == object.FALSE {
 			return object.FALSE
@@ -194,6 +197,9 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 			return object.TRUE
 		}
 		right := s.Eval(node.Right)
+		if right.Type() == object.ERROR {
+			return right
+		}
 		return s.evalInfixExpression(node.Type(), left, right)
 
 	case *ast.IntegerLiteral:
@@ -757,7 +763,7 @@ func (s *State) evalInfixExpression(operator token.Type, left, right object.Obje
 	case left.Type() == object.MAP && right.Type() == object.MAP:
 		return evalMapInfixExpression(operator, left, right)
 	default:
-		return object.Error{Value: "operation on non integers left=" + left.Inspect() + " right=" + right.Inspect()}
+		return object.Error{Value: "no " + operator.String() + " on left=" + left.Inspect() + " right=" + right.Inspect()}
 	}
 }
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -37,30 +37,30 @@ func (s *State) evalAssignment(right object.Object, node *ast.InfixExpression) o
 		log.LogVf("eval assign %#v to %#v", right, id.Value())
 		return s.env.Set(id.Literal(), right) // Propagate possible error (constant setting).
 	default:
-		return object.Error{Value: "assignment to non identifier: " + node.Left.Value().DebugString()}
+		return s.Error("assignment to non identifier: " + node.Left.Value().DebugString())
 	}
 }
 
 func (s *State) evalIndexAssigment(which ast.Node, index, value object.Object) object.Object {
 	if which.Value().Type() != token.IDENT {
-		return object.Error{Value: "index assignment to non identifier: " + which.Value().DebugString()}
+		return s.Error("index assignment to non identifier: " + which.Value().DebugString())
 	}
 	id, _ := which.(*ast.Identifier)
 	val, ok := s.env.Get(id.Literal())
 	if !ok {
-		return object.Error{Value: "identifier not found: " + id.Literal()}
+		return s.Error("identifier not found: " + id.Literal())
 	}
 	switch val.Type() {
 	case object.ARRAY:
 		if index.Type() != object.INTEGER {
-			return object.Error{Value: "index assignment to array with non integer index: " + index.Inspect()}
+			return s.Error("index assignment to array with non integer index: " + index.Inspect())
 		}
 		idx := index.(object.Integer).Value
 		if idx < 0 {
 			idx = int64(object.Len(val)) + idx
 		}
 		if idx < 0 || idx >= int64(object.Len(val)) {
-			return object.Error{Value: "index assignment out of bounds: " + index.Inspect()}
+			return s.Error("index assignment out of bounds: " + index.Inspect())
 		}
 		elements := object.Elements(val)
 		elements[idx] = value
@@ -83,15 +83,17 @@ func (s *State) evalIndexAssigment(which ast.Node, index, value object.Object) o
 	}
 }
 
-func argCheck[T any](msg string, n int, vararg bool, args []T) *object.Error {
+func argCheck[T any](s *State, msg string, n int, vararg bool, args []T) *object.Error {
 	if vararg {
 		if len(args) < n {
-			return &object.Error{Value: fmt.Sprintf("%s: wrong number of arguments. got=%d, want at least %d", msg, len(args), n)}
+			e := s.Errorf("%s: wrong number of arguments. got=%d, want at least %d", msg, len(args), n)
+			return &e
 		}
 		return nil
 	}
 	if len(args) != n {
-		return &object.Error{Value: fmt.Sprintf("%s: wrong number of arguments. got=%d, want=%d", msg, len(args), n)}
+		e := s.Errorf("%s: wrong number of arguments. got=%d, want=%d", msg, len(args), n)
+		return &e
 	}
 	return nil
 }
@@ -100,12 +102,12 @@ func (s *State) evalPrefixIncrDecr(operator token.Type, node ast.Node) object.Ob
 	log.LogVf("eval prefix %s", ast.DebugString(node))
 	nv := node.Value()
 	if nv.Type() != token.IDENT {
-		return object.Error{Value: "can't increment/decrement " + nv.DebugString()}
+		return s.Error("can't increment/decrement " + nv.DebugString())
 	}
 	id := nv.Literal()
 	val, ok := s.env.Get(id)
 	if !ok {
-		return object.Error{Value: "identifier not found: " + id}
+		return s.Error("identifier not found: " + id)
 	}
 	toAdd := int64(1)
 	if operator == token.DECR {
@@ -117,7 +119,7 @@ func (s *State) evalPrefixIncrDecr(operator token.Type, node ast.Node) object.Ob
 	case object.Float:
 		return s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)}) // So PI++ fails not silently.
 	default:
-		return object.Error{Value: "can't increment/decrement " + val.Type().String()}
+		return s.Error("can't increment/decrement " + val.Type().String())
 	}
 }
 
@@ -126,7 +128,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	id := node.Prev.Literal()
 	val, ok := s.env.Get(id)
 	if !ok {
-		return object.Error{Value: "identifier not found: " + id}
+		return s.Error("identifier not found: " + id)
 	}
 	var toAdd int64
 	switch node.Type() {
@@ -135,7 +137,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	case token.DECR:
 		toAdd = -1
 	default:
-		return object.Error{Value: "unknown postfix operator: " + node.Type().String()}
+		return s.Error("unknown postfix operator: " + node.Type().String())
 	}
 	var oerr object.Object
 	switch val := val.(type) {
@@ -144,7 +146,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 	case object.Float:
 		oerr = s.env.Set(id, object.Float{Value: val.Value + float64(toAdd)}) // So PI++ fails not silently.
 	default:
-		return object.Error{Value: "can't increment/decrement " + val.Type().String()}
+		return s.Error("can't increment/decrement " + val.Type().String())
 	}
 	if oerr.Type() == object.ERROR {
 		return oerr
@@ -278,11 +280,11 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 			}
 			index = s.evalInternal(node.Index)
 		}
-		return evalIndexExpression(left, index)
+		return s.evalIndexExpression(left, index)
 	case *ast.Comment:
 		return object.NULL
 	}
-	return object.Error{Value: fmt.Sprintf("unknown node type: %T", node)}
+	return s.Errorf("unknown node type: %T", node)
 }
 
 func (s *State) evalMapLiteral(node *ast.MapLiteral) object.Object {
@@ -293,7 +295,7 @@ func (s *State) evalMapLiteral(node *ast.MapLiteral) object.Object {
 		key := s.evalInternal(keyNode)
 		if !object.Equals(key, key) {
 			log.Warnf("key %s is not hashable", key.Inspect())
-			return object.Error{Value: "key " + key.Inspect() + " is not hashable"}
+			return s.Error("key " + key.Inspect() + " is not hashable")
 		}
 		value := s.evalInternal(valueNode)
 		result = result.Set(key, value)
@@ -319,7 +321,7 @@ func (s *State) evalPrintLogError(node *ast.Builtin) object.Object {
 		}
 	}
 	if node.Type() == token.ERROR {
-		return object.Error{Value: buf.String()}
+		return s.Error(buf.String())
 	}
 	if (s.NoLog && doLog) || node.Type() == token.PRINTLN {
 		buf.WriteRune('\n') // log() has a implicit newline when using log.Xxx, print() doesn't, println() does.
@@ -349,7 +351,7 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 		minV = 0
 		varArg = true
 	}
-	if oerr := argCheck(node.Literal(), minV, varArg, node.Parameters); oerr != nil {
+	if oerr := argCheck(s, node.Literal(), minV, varArg, node.Parameters); oerr != nil {
 		return *oerr
 	}
 	if t == token.QUOTE {
@@ -374,11 +376,11 @@ func (s *State) evalBuiltin(node *ast.Builtin) object.Object {
 	case token.LEN:
 		l := object.Len(val)
 		if l == -1 {
-			return object.Error{Value: "len: not supported on " + val.Type().String()}
+			return s.Error("len: not supported on " + val.Type().String())
 		}
 		return object.Integer{Value: int64(l)}
 	default:
-		return object.Error{Value: fmt.Sprintf("builtin %s yet implemented", node.Type())}
+		return s.Errorf("builtin %s yet implemented", node.Type())
 	}
 }
 
@@ -393,7 +395,7 @@ func (s *State) evalIndexRangeExpression(left object.Object, leftIdx, rightIdx a
 		log.Debugf("eval index %s[%s:%s]", left.Inspect(), leftIndex.Inspect(), rightIndex.Inspect())
 	}
 	if leftIndex.Type() != object.INTEGER || (!nilRight && rightIndex.Type() != object.INTEGER) {
-		return object.Error{Value: "range index not integer"}
+		return s.Error("range index not integer")
 	}
 	num := object.Len(left)
 	l := leftIndex.(object.Integer).Value
@@ -410,7 +412,7 @@ func (s *State) evalIndexRangeExpression(left object.Object, leftIdx, rightIdx a
 		}
 	}
 	if l > r {
-		return object.Error{Value: "range index invalid: left greater then right"}
+		return s.Error("range index invalid: left greater then right")
 	}
 	l = min(l, int64(num))
 	r = min(r, int64(num))
@@ -425,11 +427,11 @@ func (s *State) evalIndexRangeExpression(left object.Object, leftIdx, rightIdx a
 	case left.Type() == object.NIL:
 		return object.NULL
 	default:
-		return object.Error{Value: "range index operator not supported: " + left.Type().String()}
+		return s.Error("range index operator not supported: " + left.Type().String())
 	}
 }
 
-func evalIndexExpression(left, index object.Object) object.Object {
+func (s *State) evalIndexExpression(left, index object.Object) object.Object {
 	idxOrZero := index
 	if idxOrZero.Type() == object.NIL {
 		idxOrZero = object.Integer{Value: 0}
@@ -453,7 +455,7 @@ func evalIndexExpression(left, index object.Object) object.Object {
 	case left.Type() == object.NIL:
 		return object.NULL
 	default:
-		return object.Error{Value: "index operator not supported: " + left.Type().String() + "[" + index.Type().String() + "]"}
+		return s.Error("index operator not supported: " + left.Type().String() + "[" + index.Type().String() + "]")
 	}
 }
 
@@ -523,7 +525,7 @@ func (s *State) applyExtension(fn object.Extension, args []object.Object) object
 func (s *State) applyFunction(name string, fn object.Object, args []object.Object) object.Object {
 	function, ok := fn.(object.Function)
 	if !ok {
-		return object.Error{Value: "not a function: " + fn.Type().String() + ":" + fn.Inspect()}
+		return s.Error("not a function: " + fn.Type().String() + ":" + fn.Inspect())
 	}
 	if v, output, ok := s.cache.Get(function.CacheKey, args); ok {
 		log.Debugf("Cache hit for %s %v", function.CacheKey, args)
@@ -644,7 +646,7 @@ func (s *State) evalIdentifier(node *ast.Identifier) object.Object {
 	}
 	val, ok = s.Extensions[node.Literal()]
 	if !ok {
-		return object.Error{Value: "identifier not found: " + node.Literal()}
+		return s.Error("identifier not found: " + node.Literal())
 	}
 	return val
 }
@@ -659,7 +661,7 @@ func (s *State) evalIfExpression(ie *ast.IfExpression) object.Object {
 		log.LogVf("if %s is object.FALSE, picking else branch", ie.Condition.Value().DebugString())
 		return s.evalInternal(ie.Alternative)
 	default:
-		return object.Error{Value: "condition is not a boolean: " + condition.Inspect()}
+		return s.Error("condition is not a boolean: " + condition.Inspect())
 	}
 }
 
@@ -698,12 +700,12 @@ func (s *State) evalPrefixExpression(operator token.Type, right object.Object) o
 		if right.Type() == object.INTEGER {
 			return object.Integer{Value: ^right.(object.Integer).Value}
 		}
-		return object.Error{Value: "bitwise not of " + right.Inspect()}
+		return s.Error("bitwise not of " + right.Inspect())
 	case token.PLUS:
 		// nothing do with unary plus, just return the value.
 		return right
 	default:
-		return object.Error{Value: "unknown operator: " + operator.String()}
+		return s.Error("unknown operator: " + operator.String())
 	}
 }
 
@@ -716,7 +718,7 @@ func (s *State) evalBangOperatorExpression(right object.Object) object.Object {
 	case object.NULL:
 		return object.TRUE // allow !nil == true
 	default:
-		return object.Error{Value: "not of " + right.Inspect()}
+		return s.Error("not of " + right.Inspect())
 	}
 }
 
@@ -729,7 +731,7 @@ func (s *State) evalMinusPrefixOperatorExpression(right object.Object) object.Ob
 		value := right.(object.Float).Value
 		return object.Float{Value: -value}
 	default:
-		return object.Error{Value: "minus of " + right.Inspect()}
+		return s.Error("minus of " + right.Inspect())
 	}
 }
 
@@ -753,17 +755,17 @@ func (s *State) evalInfixExpression(operator token.Type, left, right object.Obje
 		return object.NativeBoolToBooleanObject(left == object.TRUE || right == object.TRUE)
 		// can't use generics :/ see other comment.
 	case left.Type() == object.INTEGER && right.Type() == object.INTEGER:
-		return evalIntegerInfixExpression(operator, left, right)
+		return s.evalIntegerInfixExpression(operator, left, right)
 	case left.Type() == object.FLOAT || right.Type() == object.FLOAT:
-		return evalFloatInfixExpression(operator, left, right)
+		return s.evalFloatInfixExpression(operator, left, right)
 	case left.Type() == object.STRING:
 		return evalStringInfixExpression(operator, left, right)
 	case left.Type() == object.ARRAY:
-		return evalArrayInfixExpression(operator, left, right)
+		return s.evalArrayInfixExpression(operator, left, right)
 	case left.Type() == object.MAP && right.Type() == object.MAP:
 		return evalMapInfixExpression(operator, left, right)
 	default:
-		return object.Error{Value: "no " + operator.String() + " on left=" + left.Inspect() + " right=" + right.Inspect()}
+		return s.Error("no " + operator.String() + " on left=" + left.Inspect() + " right=" + right.Inspect())
 	}
 }
 
@@ -784,17 +786,17 @@ func evalStringInfixExpression(operator token.Type, left, right object.Object) o
 	}
 }
 
-func evalArrayInfixExpression(operator token.Type, left, right object.Object) object.Object {
+func (s *State) evalArrayInfixExpression(operator token.Type, left, right object.Object) object.Object {
 	leftVal := object.Elements(left)
 	switch operator {
 	case token.ASTERISK: // repeat
 		if right.Type() != object.INTEGER {
-			return object.Error{Value: "right operand of * on arrays must be an integer"}
+			return s.Error("right operand of * on arrays must be an integer")
 		}
 		// TODO: go1.23 use	slices.Repeat
 		rightVal := right.(object.Integer).Value
 		if rightVal < 0 {
-			return object.Error{Value: "right operand of * on arrays must be a positive integer"}
+			return s.Error("right operand of * on arrays must be a positive integer")
 		}
 		result := object.MakeObjectSlice(len(leftVal) * int(rightVal))
 		for range rightVal {
@@ -830,7 +832,7 @@ func evalMapInfixExpression(operator token.Type, left, right object.Object) obje
 // can't use fields directly in generic code,
 // https://github.com/golang/go/issues/48522
 // would need getters/setters which is not very go idiomatic.
-func evalIntegerInfixExpression(operator token.Type, left, right object.Object) object.Object {
+func (s *State) evalIntegerInfixExpression(operator token.Type, left, right object.Object) object.Object {
 	leftVal := left.(object.Integer).Value
 	rightVal := right.(object.Integer).Value
 
@@ -858,7 +860,7 @@ func evalIntegerInfixExpression(operator token.Type, left, right object.Object) 
 	case token.COLON:
 		lg := rightVal - leftVal
 		if lg < 0 {
-			return object.Error{Value: "range index invalid: left greater then right"}
+			return s.Error("range index invalid: left greater then right")
 		}
 		arr := object.MakeObjectSlice(int(lg))
 		for i := leftVal; i < rightVal; i++ {
@@ -866,28 +868,29 @@ func evalIntegerInfixExpression(operator token.Type, left, right object.Object) 
 		}
 		return object.NewArray(arr)
 	default:
-		return object.Error{Value: "unknown operator: " + operator.String()}
+		return s.Error("unknown operator: " + operator.String())
 	}
 }
 
-func getFloatValue(o object.Object) (float64, *object.Error) {
+func (s *State) getFloatValue(o object.Object) (float64, *object.Error) {
 	switch o.Type() {
 	case object.INTEGER:
 		return float64(o.(object.Integer).Value), nil
 	case object.FLOAT:
 		return o.(object.Float).Value, nil
 	default:
-		return math.NaN(), &object.Error{Value: "not converting to float: " + o.Type().String()}
+		e := s.Error("not converting to float: " + o.Type().String())
+		return math.NaN(), &e
 	}
 }
 
 // So we copy-pasta instead :-(.
-func evalFloatInfixExpression(operator token.Type, left, right object.Object) object.Object {
-	leftVal, oerr := getFloatValue(left)
+func (s *State) evalFloatInfixExpression(operator token.Type, left, right object.Object) object.Object {
+	leftVal, oerr := s.getFloatValue(left)
 	if oerr != nil {
 		return *oerr
 	}
-	rightVal, oerr := getFloatValue(right)
+	rightVal, oerr := s.getFloatValue(right)
 	if oerr != nil {
 		return *oerr
 	}
@@ -903,6 +906,6 @@ func evalFloatInfixExpression(operator token.Type, left, right object.Object) ob
 	case token.PERCENT:
 		return object.Float{Value: math.Mod(leftVal, rightVal)}
 	default:
-		return object.Error{Value: "unknown operator: " + operator.String()}
+		return s.Error("unknown operator: " + operator.String())
 	}
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -291,11 +291,11 @@ func TestErrorHandling(t *testing.T) {
 		},
 		{
 			"5 + true;",
-			"operation on non integers left=5 right=true",
+			"no PLUS on left=5 right=true",
 		},
 		{
 			"5 + true; 5;",
-			"operation on non integers left=5 right=true",
+			"no PLUS on left=5 right=true",
 		},
 		{
 			"-true",
@@ -303,15 +303,15 @@ func TestErrorHandling(t *testing.T) {
 		},
 		{
 			"true + false;",
-			"operation on non integers left=true right=false",
+			"no PLUS on left=true right=false",
 		},
 		{
 			"5; true + false; 5",
-			"operation on non integers left=true right=false",
+			"no PLUS on left=true right=false",
 		},
 		{
 			"if (10 > 1) { true + false; }",
-			"operation on non integers left=true right=false",
+			"no PLUS on left=true right=false",
 		},
 		{
 			`
@@ -323,7 +323,7 @@ if (10 > 1) {
   return 1;
 }
 `,
-			"operation on non integers left=true right=false",
+			"no PLUS on left=true right=false",
 		},
 		{
 			"foobar",
@@ -974,7 +974,7 @@ func TestSmallMapSorting(t *testing.T) {
 }
 
 func TestCrashKeys(t *testing.T) {
-	inp := `keys(info.all_ids[0])`
+	inp := `keys({1:1,2:2,3:3,4:4,5:5,6:6,7:7,8:8,9:9})` // Big map and big array (>8 elements).
 	s := eval.NewState()
 	_, err := eval.EvalString(s, inp, false)
 	if err != nil {

--- a/eval/stack.go
+++ b/eval/stack.go
@@ -1,0 +1,35 @@
+package eval
+
+import (
+	"fmt"
+
+	"fortio.org/log"
+	"grol.io/grol/object"
+)
+
+// Returns a stack array of the current stack.
+func (s *State) Stack() []string {
+	stack := make([]string, 0, s.depth) // will be -1 because no name at toplevel but... it's fine.
+	e := s.env
+	for {
+		if e == nil {
+			break
+		}
+		n := e.Name()
+		if n != "" {
+			stack = append(stack, e.Name())
+		}
+		e = e.Parent()
+	}
+	log.Debugf("Stack() len %d, depth %d returning %v", len(stack), s.depth, stack)
+	return stack
+}
+
+// Creates a new error object with the given message and stack.
+func (s *State) Error(msg string) object.Error {
+	return object.Error{Value: msg, Stack: s.Stack()}
+}
+
+func (s *State) Errorf(format string, args ...interface{}) object.Error {
+	return s.Error(fmt.Sprintf(format, args...))
+}

--- a/eval/stack.go
+++ b/eval/stack.go
@@ -19,7 +19,7 @@ func (s *State) Stack() []string {
 		if n != "" {
 			stack = append(stack, e.Name())
 		}
-		e = e.Parent()
+		e = e.StackParent()
 	}
 	log.Debugf("Stack() len %d, depth %d returning %v", len(stack), s.depth, stack)
 	return stack

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func Main() int {
 	commandFlag := flag.String("c", "", "command/inline script to run instead of interactive mode")
 	showParse := flag.Bool("parse", false, "show parse tree")
 	allParens := flag.Bool("parse-debug", false, "show all parenthesis in parse tree (default is to simplify using precedence)")
-	format := flag.Bool("format", false, "don't execute, just parse and re format the input")
+	format := flag.Bool("format", false, "don't execute, just parse and reformat the input")
 	compact := flag.Bool("compact", false, "When printing code, use no indentation and most compact form")
 	showEval := flag.Bool("eval", true, "show eval results")
 	sharedState := flag.Bool("shared-state", false, "All files share same interpreter state (default is new state for each)")

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -258,7 +258,14 @@ stdout '^4$'
 # stack trace in errors
 !grol -quiet -c 'func level1(){1+"x"}; func level2(){level1()}; func level3(){level2()}; level3()'
 stderr 'Total 1 error'
-stderr '^<err: no PLUS on left=1 right="x" \[func level1\(\){1\+"x"} func level2\(\){level1\(\)} func level3\(\){level2\(\)}\]>$'
+stderr '^<err: no PLUS on left=1 right="x", stack below:>$'
+stderr '^func level1\(\){1\+"x"}$'
+stderr '^func level2\(\){level1\(\)}$'
+stderr '^func level3\(\){level2\(\)}$'
+
+!grol -quiet -c 'func level1(){1+"x"}; level1()'
+stderr 'Total 1 error'
+stderr '^<err: no PLUS on left=1 right="x" in func level1\(\){1\+"x"}>$'
 
 -- json_output --
 {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -255,6 +255,10 @@ stdout '^\(\)=>if 1\+2==3\{4\}$'
 grol -quiet -c '(()=> if 1+2==3 {4})()'
 stdout '^4$'
 
+# stack trace in errors
+!grol -quiet -c 'func level1(){1+"x"}; func level2(){level1()}; func level3(){level2()}; level3()'
+stderr 'Total 1 error'
+stderr '^<err: no PLUS on left=1 right="x" \[func level1\(\){1\+"x"} func level2\(\){level1\(\)} func level3\(\){level2\(\)}\]>$'
 
 -- json_output --
 {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -122,7 +122,7 @@ stdout '^3$'
 
 # eval() runs in the same context as when called
 grol -quiet -c 'func foo(x) {eval("info")};foo(42)["all_ids"][1]'
-stdout '^{"self":func foo\(x\){eval\("info"\)},"x":42}$'
+stdout '^\["self","x"\]$'
 !stderr .
 
 # json of (nested) arrays
@@ -212,10 +212,6 @@ stderr 'parser error'
 !stderr '\[CRI\]'
 stderr 'parser error'
 stderr '@'
-
-# panic on keys() of large array
-grol -quiet -panic -c 'keys(info.all_ids[0])'
-!stderr panic
 
 # range
 grol -quiet -c '(23:31)[4:]'

--- a/object/object.go
+++ b/object/object.go
@@ -469,6 +469,7 @@ func (n Null) Inspect() string   { return "nil" }
 
 type Error struct {
 	Value string // message
+	Stack []string
 }
 
 func (e Error) JSON(w io.Writer) error {
@@ -478,7 +479,12 @@ func (e Error) JSON(w io.Writer) error {
 func (e Error) Unwrap(_ bool) any { return e }
 func (e Error) Error() string     { return e.Value }
 func (e Error) Type() Type        { return ERROR }
-func (e Error) Inspect() string   { return "<err: " + e.Value + ">" }
+func (e Error) Inspect() string {
+	if len(e.Stack) == 0 {
+		return fmt.Sprintf("<err: %s>", e.Value)
+	}
+	return fmt.Sprintf("<err: %s %v>", e.Value, e.Stack)
+}
 
 type ReturnValue struct {
 	Value Object

--- a/object/object.go
+++ b/object/object.go
@@ -483,7 +483,18 @@ func (e Error) Inspect() string {
 	if len(e.Stack) == 0 {
 		return fmt.Sprintf("<err: %s>", e.Value)
 	}
-	return fmt.Sprintf("<err: %s %v>", e.Value, e.Stack)
+	if len(e.Stack) == 1 {
+		return fmt.Sprintf("<err: %s in %s>", e.Value, e.Stack[0])
+	}
+	out := strings.Builder{}
+	out.WriteString("<err: ")
+	out.WriteString(e.Value)
+	out.WriteString(", stack below:>")
+	for _, s := range e.Stack {
+		out.WriteByte('\n')
+		out.WriteString(s)
+	}
+	return out.String()
 }
 
 type ReturnValue struct {

--- a/object/state.go
+++ b/object/state.go
@@ -124,7 +124,7 @@ func (e *Environment) RegisterTrie(t *trie.Trie) {
 	for k, v := range e.store {
 		record(t, k, v.Type())
 	}
-	t.Insert("info ") // magic extra identifier (need the space)
+	t.Insert("info ") // magic extra identifier (need the space).
 }
 
 // Returns the number of ids written. maxValueLen <= 0 means no limit.

--- a/object/state.go
+++ b/object/state.go
@@ -82,12 +82,16 @@ func (e *Environment) BaseInfo() *BigMap {
 func (e *Environment) Info() Object {
 	allKeys := make([]Object, e.depth+1)
 	for {
-		val := &BigMap{}
-		val.kv = make([]keyValuePair, 0, e.Len())
-		for k, v := range e.store {
-			val.Set(String{Value: k}, v)
+		keys := make([]string, 0, len(e.store))
+		for k := range e.store {
+			keys = append(keys, k)
 		}
-		allKeys[e.depth] = val
+		slices.Sort(keys)
+		arr := MakeObjectSlice(len(keys))
+		for _, k := range keys {
+			arr = append(arr, String{Value: k})
+		}
+		allKeys[e.depth] = NewArray(arr)
 		if e.outer == nil {
 			break
 		}

--- a/object/state.go
+++ b/object/state.go
@@ -120,7 +120,7 @@ func (e *Environment) RegisterTrie(t *trie.Trie) {
 	for k, v := range e.store {
 		record(t, k, v.Type())
 	}
-	t.Insert("info") // magic extra identifier.
+	t.Insert("info ") // magic extra identifier (need the space)
 }
 
 // Returns the number of ids written. maxValueLen <= 0 means no limit.

--- a/object/state.go
+++ b/object/state.go
@@ -258,3 +258,14 @@ func NewFunctionEnvironment(fn Function, current *Environment) (*Environment, bo
 	env := &Environment{store: make(map[string]Object), outer: parent, cacheKey: fn.CacheKey, depth: parent.depth + 1}
 	return env, sameFunction
 }
+
+// Frame/stack name.
+func (e *Environment) Name() string {
+	return e.cacheKey
+}
+
+// Allows eval and others to walk up the stack of envs themselves
+// (using Name() to produce a stack trace for instance).
+func (e *Environment) Parent() *Environment {
+	return e.outer
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -378,7 +378,7 @@ func TestInvalidToken(t *testing.T) {
 	// This turns into the invalid token which in turn can't be found in prefix map,
 	// it used to crash in earlier versions, this is the regression for that crash.
 	// it also checks the error message in first line + first column case.
-	inp := "@"
+	inp := "\n\n@" // 3rd line.
 	l := lexer.New(inp)
 	p := parser.New(l)
 	_ = p.ParseProgram()
@@ -386,7 +386,7 @@ func TestInvalidToken(t *testing.T) {
 	if len(errs) != 1 {
 		t.Fatalf("expecting 1 error, got %d", len(errs))
 	}
-	expected := "no prefix parse function for `@` found:\n@\n^"
+	expected := "3: no prefix parse function for `@` found:\n@\n^"
 	if errs[0] != expected {
 		t.Errorf("unexpected error: wanted %q got %q", expected, errs[0])
 	}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -228,6 +228,7 @@ func Interactive(options Options) int {
 	for k := range object.ExtraFunctions() {
 		autoComplete.Trie.Insert(k + "(")
 	}
+	autoComplete.Trie.Insert("history") // add this one as it's not in the language but handled here.
 	// Initial ids and functions.
 	s.RegisterTrie(autoComplete.Trie)
 	term.SetAutoCompleteCallback(autoComplete.AutoComplete())


### PR DESCRIPTION
- Output the line number as part of parsing errors
- fix autocomplete for info, add history to autocomplete
- remove values from info.all_ids, make error abort sooner in expressions, better error message for invalid operations
- stack trace on errors

```go
$ func level1(){1+"x"}; func level2(){level1()}; func level3(){level2()}; level3()
<err: no PLUS on left=1 right="x", stack below:>
func level1(){1+"x"}
func level2(){level1()}
func level3(){level2()}
$ level1()
<err: no PLUS on left=1 right="x" in func level1(){1+"x"}>
$ 1+"a"
<err: no PLUS on left=1 right="a">
```
