### PR TITLE
Also short circuit prefix when there is an error already/so we get a single error

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -155,7 +155,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 }
 
 // Doesn't unwrap return - return bubbles up.
-func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo // quite a lot of cases.
+func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo,gocognit // quite a lot of cases.
 	switch node := node.(type) {
 	// Statements
 	case *ast.Statements:
@@ -176,6 +176,9 @@ func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo /
 			return s.evalPrefixIncrDecr(node.Type(), node.Right)
 		default:
 			right := s.evalInternal(node.Right)
+			if right.Type() == object.ERROR {
+				return right
+			}
 			return s.evalPrefixExpression(node.Type(), right)
 		}
 	case *ast.PostfixExpression:

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -273,6 +273,11 @@ grol -quiet -c 'f=()=>{{"k":"v"}}; println(json_go(f))'
 !stdout 'json: unsupported type'
 stdout '^"\(\)=>{{\\"k\\":\\"v\\"}}"$'
 
+# prefix operator single error (used to be <err: bitwise not of <err: bitwise not of <err: bitwise not of 1.1>>>)
+!grol -quiet -c '~~~1.1'
+stderr 'Total 1 error'
+stderr '^<err: bitwise not of 1.1>$'
+
 -- json_output --
 {
   "63": 63,


### PR DESCRIPTION
before:
```
$ grol -quiet -c '~~~1.1'
09:34:48.081 [ERR] Total 1 error:
<err: bitwise not of <err: bitwise not of <err: bitwise not of 1.1>>>
```

now
```
09:35:04.640 [ERR] Total 1 error:
<err: bitwise not of 1.1>
```