### PR TITLE
Add MaxDuration option and context/timeout, Add `time()` time in seconds, usec resolution, Add `sleep()`

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -6,6 +6,7 @@ on:
       # so a vX.Y.Z-test1 doesn't trigger build - no ancho working yet first one doesn't match -test1 (!)
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-pre[0-9]*'
+      - 'v[0-9]+.[0-9]+.[0-9]+\+'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -6,7 +6,6 @@ on:
       # so a vX.Y.Z-test1 doesn't trigger build - no ancho working yet first one doesn't match -test1 (!)
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-pre[0-9]*'
-      - 'v[0-9]+.[0-9]+.[0-9]+\+'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ flags:
     	history file to use (default "~/.grol_history")
   -max-depth int
     	Maximum interpreter depth (default 194999)
+  -max-duration duration
+    	Maximum duration for a script to run. 0 for unlimited. (default 10s)
   -max-history size
     	max history size, use 0 to disable. (default 99)
   -max-save-len int

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -156,6 +156,9 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 
 // Doesn't unwrap return - return bubbles up.
 func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo,gocognit // quite a lot of cases.
+	if s.Context != nil && s.Context.Err() != nil {
+		return s.Error(s.Context.Err())
+	}
 	switch node := node.(type) {
 	// Statements
 	case *ast.Statements:

--- a/eval/stack.go
+++ b/eval/stack.go
@@ -59,22 +59,3 @@ func (s *State) Error(err error) object.Object {
 	}
 	return s.NewError(err.Error())
 }
-
-/*
-// IsNilError checks if an error is nil, including if it's a non-nil interface wrapping a nil value.
-func IsNilError(err error) bool {
-	if err == nil {
-		return true
-	}
-	// Get the reflected value of the error
-	val := reflect.ValueOf(err)
-
-	// Check if the error is a pointer or interface and if it is nil
-	switch val.Kind() {
-	case reflect.Ptr, reflect.Interface:
-		return val.IsNil()
-	default:
-		return false
-	}
-}
-*/

--- a/eval/stack.go
+++ b/eval/stack.go
@@ -19,8 +19,22 @@ func (s *State) Stack() []string {
 			stack = append(stack, e.Name())
 		}
 	}
-	log.Debugf("Stack() len %d, depth %d returning %v", len(stack), s.depth, stack)
-	return stack
+	limited := LimitStack(stack, 10)
+	log.Debugf("Stack() len %d, depth %d returning %v", len(stack), s.depth, limited)
+	return limited
+}
+
+// Will use top and bottom N/2 elements of the stack to create a string.
+func LimitStack(stack []string, limit int) []string {
+	if len(stack) <= limit {
+		return stack
+	}
+	limited := make([]string, 0, limit+1)
+	limit /= 2
+	limited = append(limited, stack[:limit]...)
+	limited = append(limited, fmt.Sprintf("... %d more ...", len(stack)-limit*2))
+	limited = append(limited, stack[len(stack)-limit:]...)
+	return limited
 }
 
 // NewError creates a new error object from a plain string.
@@ -38,6 +52,29 @@ func (s *State) Errorf(format string, args ...interface{}) object.Error {
 }
 
 // Error converts from a go error to an object.Error.
-func (s *State) Error(err error) object.Error {
+// If the error is nil, it returns object.NULL instead (no error).
+func (s *State) Error(err error) object.Object {
+	if err == nil {
+		return object.NULL
+	}
 	return s.NewError(err.Error())
 }
+
+/*
+// IsNilError checks if an error is nil, including if it's a non-nil interface wrapping a nil value.
+func IsNilError(err error) bool {
+	if err == nil {
+		return true
+	}
+	// Get the reflected value of the error
+	val := reflect.ValueOf(err)
+
+	// Check if the error is a pointer or interface and if it is nil
+	switch val.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		return val.IsNil()
+	default:
+		return false
+	}
+}
+*/

--- a/examples/pi2.gr
+++ b/examples/pi2.gr
@@ -13,4 +13,5 @@ n = 149_990 // close to 150_000 default limit.
 now = time()
 pi = f(1, n, 1)
 elapsed = time() - now
-println("calculated pi = ", pi, " in ", elapsed, " seconds")
+log("calculated pi = ", pi, " in ", elapsed, " seconds")
+pi

--- a/examples/pi2.gr
+++ b/examples/pi2.gr
@@ -10,4 +10,7 @@ f = func(i, n, prod) {
 	self(i+1, n, prod*(1-1./(2*i)))
 }
 n = 149_990 // close to 150_000 default limit.
-f(1, n, 1)
+now = time()
+pi = f(1, n, 1)
+elapsed = time() - now
+println("calculated pi = ", pi, " in ", elapsed, " seconds")

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -55,35 +55,25 @@ func Init(c *Config) error {
 	return errInInit
 }
 
+func MustCreate(ext object.Extension) {
+	err := object.CreateFunction(ext)
+	if err != nil {
+		panic(err)
+	}
+}
+
 type OneFloatInOutFunc func(float64) float64
 
-func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx // yeah we add a bunch of stuff.
+func initInternal(c *Config) error {
 	unrestrictedIOs = c.UnrestrictedIOs
 	emptyOnly = c.LoadSaveEmptyOnly
-	cmd := object.Extension{
-		Name:     "pow",
-		MinArgs:  2,
-		MaxArgs:  2,
-		ArgTypes: []object.Type{object.FLOAT, object.FLOAT},
-		Callback: object.ShortCallback(pow),
-	}
-	err := object.CreateFunction(cmd)
-	if err != nil {
-		return err
-	}
-	err = object.CreateFunction(object.Extension{
-		Name:     "sprintf",
-		MinArgs:  1,
-		MaxArgs:  -1,
-		ArgTypes: []object.Type{object.STRING},
-		Callback: object.ShortCallback(sprintf),
-	})
-	if err != nil {
-		return err
-	}
+
+	// -- These AddEvalResult should probably be like for discord bot,
+	// a separate grol library file embedded in the binary and read/saved in state instead.
+
 	// for printf, we could expose current eval "Out", but instead let's use new variadic support and define
 	// printf as print(snprintf(format,..)) that way the memoization of output also works out of the box.
-	err = eval.AddEvalResult("printf", "func(format, ..){print(sprintf(format, ..))}")
+	err := eval.AddEvalResult("printf", "func(format, ..){print(sprintf(format, ..))}")
 	if err != nil {
 		return err
 	}
@@ -103,6 +93,30 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	object.AddIdentifier("null", object.NULL)
 	object.AddIdentifier("NaN", object.Float{Value: math.NaN()})
 	object.AddIdentifier("Inf", object.Float{Value: math.Inf(0)}) // Works for both -Inf and +Inf (thanks to noop unary +).
+	object.AddIdentifier("PI", object.Float{Value: math.Pi})
+	object.AddIdentifier("E", object.Float{Value: math.E}) // using uppercase so "e" isn't taken/shadowed.
+
+	// --- Real extension section starts here.
+
+	// First one we don't use MustCreate in case it'd error out and we want to return that error.
+	err = object.CreateFunction(object.Extension{
+		Name:     "pow",
+		MinArgs:  2,
+		MaxArgs:  2,
+		ArgTypes: []object.Type{object.FLOAT, object.FLOAT},
+		Callback: object.ShortCallback(pow),
+	})
+	if err != nil {
+		return err
+	}
+	// Next ones we don't want to keep adding if err != nil ..., so we use MustCreate.
+	MustCreate(object.Extension{
+		Name:     "sprintf",
+		MinArgs:  1,
+		MaxArgs:  -1,
+		ArgTypes: []object.Type{object.STRING},
+		Callback: object.ShortCallback(sprintf),
+	})
 
 	oneFloat := object.Extension{
 		MinArgs:  1,
@@ -134,13 +148,10 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 			return object.Float{Value: function.fn(args[0].(object.Float).Value)}
 		}
 		oneFloat.Name = function.name
-		err = object.CreateFunction(oneFloat)
-		if err != nil {
-			return err
-		}
+		MustCreate(oneFloat)
 	}
 	// rand() and rand(n) functions.
-	randFn := object.Extension{
+	MustCreate(object.Extension{
 		Name:     "rand",
 		MinArgs:  0,
 		MaxArgs:  1,
@@ -156,27 +167,22 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 			}
 			return object.Integer{Value: rand.Int64N(n)} //nolint:gosec // no need for crypto/rand here.
 		},
-	}
-	err = object.CreateFunction(randFn)
-	if err != nil {
-		return err
-	}
-	timeFn := object.Extension{
-		Name:    "time",
-		MinArgs: 0,
-		MaxArgs: 0,
-		Help:    "Date/time in seconds since epoch",
-		Callback: func(env any, _ string, _ []object.Object) object.Object {
-			eval.TriggerNoCache(env)
-			return object.Float{Value: float64(time.Now().UnixMicro()) / 1e6}
-		},
-	}
-	err = object.CreateFunction(timeFn)
-	if err != nil {
-		return err
-	}
-	object.AddIdentifier("PI", object.Float{Value: math.Pi})
-	object.AddIdentifier("E", object.Float{Value: math.E}) // using uppercase so "e" isn't taken/shadowed.
+	})
+	createJSONAndEvalFunctions(c)
+	createStrFunctions()
+	createMisc()
+	return nil
+}
+
+func createJSONAndEvalFunctions(c *Config) {
+	MustCreate(object.Extension{
+		Name:     "json_go",
+		MinArgs:  1,
+		MaxArgs:  2,
+		ArgTypes: []object.Type{object.ANY, object.STRING},
+		Callback: jsonSerGo,
+		Help:     `optional indent e.g json_go(m, "  ")`,
+	})
 	jsonFn := object.Extension{
 		Name:     "json",
 		MinArgs:  1,
@@ -184,46 +190,20 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		ArgTypes: []object.Type{object.ANY},
 		Callback: jsonSer,
 	}
-	err = object.CreateFunction(jsonFn)
-	if err != nil {
-		return err
-	}
-	jsonFn = object.Extension{
-		Name:     "json_go",
-		MinArgs:  1,
-		MaxArgs:  2,
-		ArgTypes: []object.Type{object.ANY, object.STRING},
-		Callback: jsonSerGo,
-		Help:     `optional indent e.g json_go(m, "  ")`,
-	}
-	err = object.CreateFunction(jsonFn)
-	if err != nil {
-		return err
-	}
-	jsonFn.MaxArgs = 1
-	jsonFn.Help = ""
-	jsonFn.Name = "eval"
-	jsonFn.Callback = evalFunc
-	jsonFn.ArgTypes = []object.Type{object.STRING}
-	err = object.CreateFunction(jsonFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(jsonFn)
 	jsonFn.Name = "type"
 	jsonFn.Callback = object.ShortCallback(func(args []object.Object) object.Object {
 		return object.String{Value: args[0].Type().String()}
 	})
-	jsonFn.ArgTypes = []object.Type{object.ANY}
-	err = object.CreateFunction(jsonFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(jsonFn)
+	jsonFn.Name = "eval"
+	jsonFn.Callback = evalFunc
+	jsonFn.ArgTypes = []object.Type{object.STRING}
+	MustCreate(jsonFn)
 	jsonFn.Name = "unjson"
 	jsonFn.Callback = evalFunc // unjson at the moment is just (like) eval hoping that json is map/array/...
-	err = object.CreateFunction(jsonFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(jsonFn)
+
 	loadSaveFn := object.Extension{
 		MinArgs:  0, // empty only case - ie ".gr" save file.
 		MaxArgs:  1,
@@ -233,19 +213,16 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 	if c.HasSave {
 		loadSaveFn.Name = "save"
 		loadSaveFn.Callback = saveFunc // save to file.
-		err = object.CreateFunction(loadSaveFn)
-		if err != nil {
-			return err
-		}
+		MustCreate(loadSaveFn)
 	}
 	if c.HasLoad {
 		loadSaveFn.Name = "load"
 		loadSaveFn.Callback = loadFunc // eval a file.
-		err = object.CreateFunction(loadSaveFn)
-		if err != nil {
-			return err
-		}
+		MustCreate(loadSaveFn)
 	}
+}
+
+func createStrFunctions() {
 	strFn := object.Extension{
 		MinArgs:  1,
 		MaxArgs:  1,
@@ -263,26 +240,17 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		}
 		return object.NewArray(runes)
 	}
-	err = object.CreateFunction(strFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(strFn)
 	strFn.Name = "rune_len"
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		return object.Integer{Value: int64(utf8.RuneCountInString(args[0].(object.String).Value))}
 	}
-	err = object.CreateFunction(strFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(strFn)
 	strFn.Name = "width"
 	strFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		return object.Integer{Value: int64(uniseg.StringWidth((args[0].(object.String).Value)))}
 	}
-	err = object.CreateFunction(strFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(strFn)
 	strFn.Name = "split"
 	strFn.Help = "optional separator"
 	strFn.MinArgs = 1
@@ -303,10 +271,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		}
 		return object.NewArray(strs)
 	}
-	err = object.CreateFunction(strFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(strFn)
 	strFn.Name = "join"
 	strFn.Help = "joins an array of string with the optional separator"
 	strFn.ArgTypes = []object.Type{object.ARRAY, object.STRING}
@@ -330,10 +295,10 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		object.MustBeOk(totalLen / object.ObjectSize) // off by sepLen but that's ok.
 		return object.String{Value: strings.Join(strs, sep)}
 	}
-	err = object.CreateFunction(strFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(strFn)
+}
+
+func createMisc() {
 	minMaxFn := object.Extension{
 		MinArgs:  1,
 		MaxArgs:  -1,
@@ -352,10 +317,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		}
 		return minV
 	}
-	err = object.CreateFunction(minMaxFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(minMaxFn)
 	minMaxFn.Name = "max"
 	minMaxFn.Callback = func(_ any, _ string, args []object.Object) object.Object {
 		if len(args) == 1 {
@@ -369,10 +331,7 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		}
 		return maxV
 	}
-	err = object.CreateFunction(minMaxFn)
-	if err != nil {
-		return err
-	}
+	MustCreate(minMaxFn)
 
 	intFn := object.Extension{
 		Name:     "int",
@@ -405,12 +364,20 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 			}
 		},
 	}
-	err = object.CreateFunction(intFn)
-	if err != nil {
-		return err
-	}
-	return nil
+	MustCreate(intFn)
+	MustCreate(object.Extension{
+		Name:    "time",
+		MinArgs: 0,
+		MaxArgs: 0,
+		Help:    "Date/time in seconds since epoch",
+		Callback: func(env any, _ string, _ []object.Object) object.Object {
+			eval.TriggerNoCache(env)
+			return object.Float{Value: float64(time.Now().UnixMicro()) / 1e6}
+		},
+	})
 }
+
+// --- implementation of the functions that aren't inlined in lambdas above.
 
 func pow(args []object.Object) object.Object {
 	// Arg len check already done through MinArgs and MaxArgs

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"fortio.org/log"
@@ -157,6 +158,20 @@ func initInternal(c *Config) error { //nolint:funlen,gocognit,gocyclo,maintidx /
 		},
 	}
 	err = object.CreateFunction(randFn)
+	if err != nil {
+		return err
+	}
+	timeFn := object.Extension{
+		Name:    "time",
+		MinArgs: 0,
+		MaxArgs: 0,
+		Help:    "Date/time in seconds since epoch",
+		Callback: func(env any, _ string, _ []object.Object) object.Object {
+			eval.TriggerNoCache(env)
+			return object.Float{Value: float64(time.Now().UnixMicro()) / 1e6}
+		},
+	}
+	err = object.CreateFunction(timeFn)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func Main() (retcode int) {
 	maxDepth := flag.Int("max-depth", eval.DefaultMaxDepth-1, "Maximum interpreter depth")
 	maxLen := flag.Int("max-save-len", 4000, "Maximum len of saved identifiers, use 0 for unlimited")
 	panicOk := flag.Bool("panic", false, "Don't catch panic - only for development/debugging")
+	maxDuration := flag.Duration("max-duration", eval.DefaultMaxDuration, "Maximum duration for a script to run. 0 for unlimited.")
 
 	cli.ArgsHelp = "*.gr files to interpret or `-` for stdin without prompt or no arguments for stdin repl..."
 	cli.MaxArgs = -1
@@ -97,6 +98,7 @@ func Main() (retcode int) {
 		MaxValueLen: *maxLen,
 		PanicOk:     *panicOk,
 		AllParens:   *allParens,
+		MaxDuration: *maxDuration,
 	}
 	if hookBefore != nil {
 		retcode = hookBefore()

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"fortio.org/cli"
 	"fortio.org/log"
@@ -62,8 +64,9 @@ type Options struct {
 	PanicOk     bool // If true, panics are not caught (only for debugging/developing).
 	// Hook to call before running the input (lets you for instance change the ClientData of some object.Extension,
 	// remove some functions, etc).
-	PreInput  func(*eval.State)
-	AllParens bool // Show all parens in parse tree (default is to simplify using precedence).
+	PreInput    func(*eval.State)
+	AllParens   bool // Show all parens in parse tree (default is to simplify using precedence).
+	MaxDuration time.Duration
 }
 
 func AutoLoad(s *eval.State, options Options) error {
@@ -366,6 +369,7 @@ func EvalOne(s *eval.State, what string, out io.Writer, options Options) (
 			}
 		}()
 	}
+	s.SetContext(context.Background(), options.MaxDuration)
 	continuation, errs, formatted = evalOne(s, what, out, options)
 	return
 }


### PR DESCRIPTION
- `time()`
- `sleep()`
- cleanup extension.go / added MustCreate()
- max duration enforcement
- limit stack dump to 10 eg
```
16:11:05 [E] Errors: [<err: context deadline exceeded, stack below:>
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
... 1484 more ...
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}
(i,n,prod)=>{if i==n+1{return 1./(prod*prod*n)}self(i+1,n,prod*(1-1./(2*i)))}]
```
- #34 

Fixes #34 
Fixes grol-io/grol-discord-bot#4
