### PR TITLE
Adding time_parse including version without format that tries a bunch  of possible formats

### DIFF
--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -406,9 +406,14 @@ func createTimeFunctions() {
 		Callback: func(st any, _ string, args []object.Object) object.Object {
 			s := st.(*eval.State)
 			timeUsec := math.Round(args[0].(object.Float).Value * 1e6)
+			// parse_time without a TZ will be in UTC, so to echo it back the same we also default to UTC.
+			// caller can pass "Local" to get the local time.
 			t := time.UnixMicro(int64(timeUsec)).UTC()
 			if len(args) == 2 {
 				timeZone := args[1].(object.String).Value
+				if strings.EqualFold("local", timeZone) {
+					timeZone = "Local"
+				}
 				location, err := time.LoadLocation(timeZone)
 				if err != nil {
 					return s.Error(err)

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -172,6 +172,7 @@ func initInternal(c *Config) error {
 	createJSONAndEvalFunctions(c)
 	createStrFunctions()
 	createMisc()
+	createTimeFunctions()
 	return nil
 }
 
@@ -366,6 +367,9 @@ func createMisc() {
 		},
 	}
 	MustCreate(intFn)
+}
+
+func createTimeFunctions() {
 	MustCreate(object.Extension{
 		Name:    "time",
 		MinArgs: 0,
@@ -398,11 +402,11 @@ func createMisc() {
 		MinArgs:  1,
 		MaxArgs:  2,
 		ArgTypes: []object.Type{object.FLOAT, object.STRING},
-		Help:     "As returned by time(), in seconds since epoch, and optional TimeZone/location",
+		Help:     "Float as returned by time() and time_parse() in seconds since epoch, and optional TimeZone/location",
 		Callback: func(st any, _ string, args []object.Object) object.Object {
 			s := st.(*eval.State)
 			timeUsec := math.Round(args[0].(object.Float).Value * 1e6)
-			t := time.UnixMicro(int64(timeUsec))
+			t := time.UnixMicro(int64(timeUsec)).UTC()
 			if len(args) == 2 {
 				timeZone := args[1].(object.String).Value
 				location, err := time.LoadLocation(timeZone)
@@ -430,9 +434,70 @@ func createMisc() {
 			return m
 		},
 	})
+	MustCreate(object.Extension{
+		Name:     "time_parse",
+		MinArgs:  1,
+		MaxArgs:  2,
+		ArgTypes: []object.Type{object.STRING, object.STRING},
+		Help:     "Parse a time string with optional format, returns seconds since epoch",
+		Callback: func(st any, _ string, args []object.Object) object.Object {
+			s := st.(*eval.State)
+			inp := args[0].(object.String).Value
+			if len(args) == 1 {
+				t, err := TryParseTime(inp)
+				if err != nil {
+					return s.Error(err)
+				}
+				return object.Float{Value: float64(t.UnixMicro()) / 1e6}
+			}
+			format := args[1].(object.String).Value
+			t, err := time.Parse(format, inp)
+			if err != nil {
+				return s.Error(err)
+			}
+			return object.Float{Value: float64(t.UnixMicro()) / 1e6}
+		},
+	})
 }
 
 // --- implementation of the functions that aren't inlined in lambdas above.
+
+var parseFormats = []string{
+	time.RFC3339,
+	time.ANSIC,      //   = "Mon Jan _2 15:04:05 2006"
+	time.UnixDate,   //   = "Mon Jan _2 15:04:05 MST 2006"
+	time.RFC822,     //   = "02 Jan 06 15:04 MST"
+	time.RFC822Z,    //   = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
+	time.RFC850,     //   = "Monday, 02-Jan-06 15:04:05 MST"
+	time.RFC1123,    //   = "Mon, 02 Jan 2006 15:04:05 MST"
+	time.RFC1123Z,   //   = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	time.RFC3339,    //   = "2006-01-02T15:04:05Z07:00"
+	time.Kitchen,    //   = "3:04PM"
+	time.Stamp,      //   = "Jan _2 15:04:05"
+	time.StampMilli, //   = "Jan _2 15:04:05.000"
+	time.DateTime,   //   = "2006-01-02 15:04:05"
+	time.DateOnly,   //   = "2006-01-02"
+	time.TimeOnly,   //   = "15:04:05"
+	"_2 Jan 2006",
+	"_2/1/2006", // try EU (ie sensible) style first.
+	"1/_2/2006",
+	"_2-Jan-2006",
+	"02/01/06",
+	"01/02/06",
+}
+
+func TryParseTime(input string) (time.Time, error) {
+	var t time.Time
+	var err error
+	for _, format := range parseFormats { // maybe consider grouping formats by length
+		t, err = time.Parse(format, input)
+		if err == nil {
+			log.Infof("Parsed %q with format %q to %v", input, format, t)
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unable to parse time: %v", input)
+}
 
 func pow(args []object.Object) object.Object {
 	// Arg len check already done through MinArgs and MaxArgs

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -463,21 +463,20 @@ func createTimeFunctions() {
 // --- implementation of the functions that aren't inlined in lambdas above.
 
 var parseFormats = []string{
+	time.DateTime, //   = "2006-01-02 15:04:05" // first as that's what time_info().str returns (with usec).
 	time.RFC3339,
-	time.ANSIC,      //   = "Mon Jan _2 15:04:05 2006"
-	time.UnixDate,   //   = "Mon Jan _2 15:04:05 MST 2006"
-	time.RFC822,     //   = "02 Jan 06 15:04 MST"
-	time.RFC822Z,    //   = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
-	time.RFC850,     //   = "Monday, 02-Jan-06 15:04:05 MST"
-	time.RFC1123,    //   = "Mon, 02 Jan 2006 15:04:05 MST"
-	time.RFC1123Z,   //   = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
-	time.RFC3339,    //   = "2006-01-02T15:04:05Z07:00"
-	time.Kitchen,    //   = "3:04PM"
-	time.Stamp,      //   = "Jan _2 15:04:05"
-	time.StampMilli, //   = "Jan _2 15:04:05.000"
-	time.DateTime,   //   = "2006-01-02 15:04:05"
-	time.DateOnly,   //   = "2006-01-02"
-	time.TimeOnly,   //   = "15:04:05"
+	time.ANSIC,    //   = "Mon Jan _2 15:04:05 2006"
+	time.UnixDate, //   = "Mon Jan _2 15:04:05 MST 2006"
+	time.RFC822,   //   = "02 Jan 06 15:04 MST"
+	time.RFC822Z,  //   = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
+	time.RFC850,   //   = "Monday, 02-Jan-06 15:04:05 MST"
+	time.RFC1123,  //   = "Mon, 02 Jan 2006 15:04:05 MST"
+	time.RFC1123Z, //   = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	time.RFC3339,  //   = "2006-01-02T15:04:05Z07:00"
+	time.Kitchen,  //   = "3:04PM"
+	time.Stamp,    //   = "Jan _2 15:04:05"
+	time.DateOnly, //   = "2006-01-02"
+	time.TimeOnly, //   = "15:04:05"
 	"_2 Jan 2006",
 	"_2/1/2006", // try EU (ie sensible) style first.
 	"1/_2/2006",
@@ -489,10 +488,10 @@ var parseFormats = []string{
 func TryParseTime(input string) (time.Time, error) {
 	var t time.Time
 	var err error
-	for _, format := range parseFormats { // maybe consider grouping formats by length
+	for i, format := range parseFormats { // maybe consider grouping formats by length
 		t, err = time.Parse(format, input)
 		if err == nil {
-			log.Infof("Parsed %q with format %q to %v", input, format, t)
+			log.Infof("Parsed %q with format#%d: %q to %v", input, i+1, format, t)
 			return t, nil
 		}
 	}

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -282,6 +282,9 @@ stderr '^<err: bitwise not of 1.1>$'
 !grol -quiet -c '"abc" * -3'
 !stderr 'panic'
 
+# time parse round trip
+grol -quiet -c 'now=time(); time_parse(time_info(now).str) == now'
+
 -- json_output --
 {
   "63": 63,


### PR DESCRIPTION
```go
$ time_info(time_parse("8/7/2023")).str
09:43:18.776 r1 [INF] Parsed "8/7/2023" with format "_2/1/2006" to 2023-07-08 00:00:00 +0000 UTC
"2023-07-08 00:00:00"
$ time_info(time_parse("7/13/2023")).str
09:43:34.401 r1 [INF] Parsed "7/13/2023" with format "1/_2/2006" to 2023-07-13 00:00:00 +0000 UTC
"2023-07-13 00:00:00"
$ now = time()
1725295469.159619
$ time_parse(time_info(now).str)   
09:44:38.036 r1 [INF] Parsed "2024-09-02 16:44:29.159619" with format "2006-01-02 15:04:05" to 2024-09-02 16:44:29.159619 +0000 UTC
1725295469.159619
$ 
```