### PR TITLE
Fix bug with error retcode lost when running without tags/with pprof

### DIFF
--- a/examples/unsigned_binary.gr
+++ b/examples/unsigned_binary.gr
@@ -16,3 +16,7 @@ func binary(v) {
 		return binary(v>>1) + bit2str(v&1)
 	}
 }
+b = binary(~0)
+println(b)
+
+len(b) == 64

--- a/main.go
+++ b/main.go
@@ -110,9 +110,9 @@ func Main() (retcode int) {
 	}
 	defer func() {
 		if hookAfter != nil {
-			retcode = hookAfter()
+			retcode += hookAfter()
 		}
-		log.Infof("All done")
+		log.Infof("All done - retcode: %d", retcode)
 	}()
 	c := extensions.Config{
 		HasLoad:           !*disableLoadSave,


### PR DESCRIPTION
fix bug that `go test .` would fail because without the no_pprof tag, the error exit was lost

before:
```
$ go test ./...
?   	grol.io/grol/extensions	[no test files]
?   	grol.io/grol/wasm	[no test files]
--- FAIL: TestGrolCli (0.00s)
    --- FAIL: TestGrolCli/main_test (0.95s)
        testscript.go:532: # testscript framework tests for grol's main binary / command line
            # Basic usage test (0.904s)
            # (short) version (0.012s)
            # (long) version (0.011s)
            # most basic expression (0.010s)
            # syntax error non mode, stdout doesn't repeat errors (0.010s)
            > !grol -c 'foo'
            [stderr]
            12:26:50 [I] grol dev  go1.22.6 arm64 darwin - welcome!
            12:26:50 [W] Memory limit not set, please set the GOMEMLIMIT env var; e.g. GOMEMLIMIT=1GiB
            12:26:50 [I] No autoload file .gr
            12:26:50 [I] Nothing changed, not auto saving
            12:26:50 [E] Total 1 error:
            <err: identifier not found: foo>
            12:26:50 [I] All done
            FAIL: main_test.txtar:26: unexpected command success
            
FAIL
FAIL	grol.io/grol	1.222s
```