### PR TITLE
Fix lambda chaining parsing

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -20,6 +20,7 @@ const (
 	ASSIGN      // =
 	OR          // ||
 	AND         // &&
+	LAMBDA      // =>
 	EQUALS      // ==
 	LESSGREATER // > or <
 	SUM         // +
@@ -38,7 +39,7 @@ var Precedences = map[token.Type]Priority{
 	token.COLON:      AND, // range operator and maps (lower than lambda)
 	token.EQ:         EQUALS,
 	token.NOTEQ:      EQUALS,
-	token.LAMBDA:     EQUALS,
+	token.LAMBDA:     LAMBDA,
 	token.LT:         LESSGREATER,
 	token.GT:         LESSGREATER,
 	token.LTEQ:       LESSGREATER,

--- a/ast/priority_string.go
+++ b/ast/priority_string.go
@@ -12,20 +12,21 @@ func _() {
 	_ = x[ASSIGN-2]
 	_ = x[OR-3]
 	_ = x[AND-4]
-	_ = x[EQUALS-5]
-	_ = x[LESSGREATER-6]
-	_ = x[SUM-7]
-	_ = x[PRODUCT-8]
-	_ = x[DIVIDE-9]
-	_ = x[PREFIX-10]
-	_ = x[CALL-11]
-	_ = x[INDEX-12]
-	_ = x[DOTINDEX-13]
+	_ = x[LAMBDA-5]
+	_ = x[EQUALS-6]
+	_ = x[LESSGREATER-7]
+	_ = x[SUM-8]
+	_ = x[PRODUCT-9]
+	_ = x[DIVIDE-10]
+	_ = x[PREFIX-11]
+	_ = x[CALL-12]
+	_ = x[INDEX-13]
+	_ = x[DOTINDEX-14]
 }
 
-const _Priority_name = "LOWESTASSIGNORANDEQUALSLESSGREATERSUMPRODUCTDIVIDEPREFIXCALLINDEXDOTINDEX"
+const _Priority_name = "LOWESTASSIGNORANDLAMBDAEQUALSLESSGREATERSUMPRODUCTDIVIDEPREFIXCALLINDEXDOTINDEX"
 
-var _Priority_index = [...]uint8{0, 6, 12, 14, 17, 23, 34, 37, 44, 50, 56, 60, 65, 73}
+var _Priority_index = [...]uint8{0, 6, 12, 14, 17, 23, 29, 40, 43, 50, 56, 62, 66, 71, 79}
 
 func (i Priority) String() string {
 	i -= 1

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -255,6 +255,16 @@ stdout '^\(\)=>if 1\+2==3\{4\}$'
 grol -quiet -c '(()=> if 1+2==3 {4})()'
 stdout '^4$'
 
+# lamda chaining:
+grol -quiet -c '(()=>a=>b=>c=>a+b+c)()(1)(2)(3)'
+stdout '^6$'
+
+grol -quiet -c '(()=>a=>b=>()=>c=>a+b+c)()(1)(2)()(3)'
+stdout '^6$'
+
+grol -quiet -c '(()=>a=>b=>(x,y)=>c=>a+b+c+x+y)()(1)(2)(4,5)(3)'
+stdout '^15$'
+
 # stack trace in errors
 !grol -quiet -c 'func level1(){1+"x"}; func level2(){level1()}; func level3(){level2()}; level3()'
 stderr 'Total 1 error'

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -262,7 +262,7 @@ stdout '^6$'
 grol -quiet -c '(()=>a=>b=>()=>c=>a+b+c)()(1)(2)()(3)'
 stdout '^6$'
 
-grol -quiet -c '(()=>a=>b=>(x,y)=>c=>a+b+c+x+y)()(1)(2)(4,5)(3)'
+grol -quiet -c 'f= a=>b=>(x,y)=>c=>a+b+c+x+y;f(1)(2)(4,5)(3)'
 stdout '^15$'
 
 # stack trace in errors

--- a/object/object.go
+++ b/object/object.go
@@ -568,7 +568,9 @@ func (f *Function) lambdaPrint(ps *ast.PrintState, out *strings.Builder) string 
 	} else {
 		out.WriteString("=>")
 	}
-	needBraces := len(f.Body.Statements) != 1 || f.Body.Statements[0].Value().Type() == token.LBRACE
+	needBraces := len(f.Body.Statements) != 1 ||
+		f.Body.Statements[0].Value().Type() == token.LBRACE ||
+		f.Body.Statements[0].Value().Type() == token.LAMBDA
 	if needBraces {
 		out.WriteString("{")
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -305,6 +305,10 @@ func (p *Parser) parseExpression(precedence ast.Priority) ast.Node {
 		return nil
 	}
 	leftExp := prefix()
+	if p.peekTokenIs(token.LAMBDA) && precedence == ast.LAMBDA { // allow lambda chaining without parentheses in input.
+		p.nextToken()
+		return p.parseLambdaMulti(leftExp)
+	}
 	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
 		t := p.peekToken.Type()
 		infix := p.infixParseFns[t]

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -214,12 +214,22 @@ func Test_OperatorPrecedenceParsing(t *testing.T) {
 	}
 }
 
-func TestFormat(t *testing.T) {
+func TestFormat(t *testing.T) { //nolint:funlen // long table driven tests.
 	tests := []struct {
 		input    string
 		expected string
 		compact  string
 	}{
+		{
+			`a=>b=>a+b`,
+			"a => {\n\tb => {\n\t\ta + b\n\t}\n}",
+			"a=>{b=>{a+b}}",
+		},
+		{
+			"a=>{b=>{a+b}}", // check it parses back fine, unlike before https://github.com/grol-io/grol/issues/208 fix
+			"a => {\n\tb => {\n\t\ta + b\n\t}\n}",
+			"a=>{b=>{a+b}}",
+		},
 		{
 			`a=[1,2,3]
 a[1]


### PR DESCRIPTION
Fixes #208 

```go
(()=>a=>b=>c=>a+b+c)()(1)(2)(3)
```
is now `6` instead of erroring out

See tests and comments

