### PR TITLE
Add begining image function and demo and performance optimizations (10x improvements related to logging level skips)

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -533,6 +533,8 @@ func (s *State) applyExtension(fn object.Extension, args []object.Object) object
 			l, fn.Inspect())} // shows usage
 	}
 	for i, arg := range args {
+		arg = object.Value(arg) // deref.
+		args[i] = arg
 		if i >= len(fn.ArgTypes) {
 			break
 		}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -533,14 +533,15 @@ func (s *State) applyExtension(fn object.Extension, args []object.Object) object
 			l, fn.Inspect())} // shows usage
 	}
 	for i, arg := range args {
-		arg = object.Value(arg) // deref.
-		args[i] = arg
 		if i >= len(fn.ArgTypes) {
 			break
 		}
 		if fn.ArgTypes[i] == object.ANY {
 			continue
 		}
+		// deref but only if type isn't ANY - so type() gets the REFERENCES but math functions don't/get values.
+		arg = object.Value(arg)
+		args[i] = arg
 		// Auto promote integer to float if needed.
 		if fn.ArgTypes[i] == object.FLOAT && arg.Type() == object.INTEGER {
 			args[i] = object.Float{Value: float64(arg.(object.Integer).Value)}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -165,7 +165,7 @@ func (s *State) evalPostfixExpression(node *ast.PostfixExpression) object.Object
 // Doesn't unwrap return - return bubbles up.
 // Initially this was the one to use internally recursively, except for when evaluating a function
 // but now it's less clear because of the need to unwrap references too. TODO: fix/clarify.
-func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocyclo // quite a lot of cases.
+func (s *State) evalInternal(node any) object.Object { //nolint:funlen,gocognit,gocyclo // quite a lot of cases.
 	if s.Context != nil && s.Context.Err() != nil {
 		return s.Error(s.Context.Err())
 	}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -429,10 +429,14 @@ func (s *State) evalIndexRangeExpression(left object.Object, leftIdx, rightIdx a
 	nilRight := (rightIdx == nil)
 	var rightIndex object.Object
 	if nilRight {
-		log.Debugf("eval index %s[%s:]", left.Inspect(), leftIndex.Inspect())
+		if log.LogDebug() {
+			log.Debugf("eval index %s[%s:]", left.Inspect(), leftIndex.Inspect())
+		}
 	} else {
 		rightIndex = s.Eval(rightIdx)
-		log.Debugf("eval index %s[%s:%s]", left.Inspect(), leftIndex.Inspect(), rightIndex.Inspect())
+		if log.LogDebug() {
+			log.Debugf("eval index %s[%s:%s]", left.Inspect(), leftIndex.Inspect(), rightIndex.Inspect())
+		}
 	}
 	if leftIndex.Type() != object.INTEGER || (!nilRight && rightIndex.Type() != object.INTEGER) {
 		return s.NewError("range index not integer")
@@ -666,7 +670,9 @@ func (s *State) extendFunctionEnv(
 	for paramIdx, param := range params {
 		// By definition function parameters are local copies, deref argument values:
 		oerr := env.CreateOrSet(param.Value().Literal(), object.Value(args[paramIdx]), true)
-		log.LogVf("set %s to %s - %s", param.Value().Literal(), args[paramIdx].Inspect(), oerr.Inspect())
+		if log.LogVerbose() {
+			log.LogVf("set %s to %s - %s", param.Value().Literal(), args[paramIdx].Inspect(), oerr.Inspect())
+		}
 		if oerr.Type() == object.ERROR {
 			oe, _ := oerr.(object.Error)
 			return nil, &oe

--- a/eval/stack.go
+++ b/eval/stack.go
@@ -46,6 +46,10 @@ func (s *State) NewError(msg string) object.Error {
 	return object.Error{Value: msg, Stack: s.Stack()}
 }
 
+func (s *State) ErrorAddStack(e object.Error) object.Error {
+	return object.Error{Value: e.Value, Stack: s.Stack()}
+}
+
 // Errorf formats and create an object.Error using given format and args.
 func (s *State) Errorf(format string, args ...interface{}) object.Error {
 	return s.NewError(fmt.Sprintf(format, args...))

--- a/examples/image.gr
+++ b/examples/image.gr
@@ -2,39 +2,11 @@
 
 // inspiration @shokhie
 
-func hue2rgb(p, q, t) {
-    if t < 0 {
-        t++
-    }
-    if t > 1 {
-        t--
-    }
-    if t < 1. / 6. {
-        return p + (q - p) * 6. * t
-    }
-    if t < 1. / 2. {
-        return q
-    }
-    if t < 2. / 3. {
-        return p + (q - p) * (2. / 3. - t) * 6.
-    }
-    return p
-}
-
-func hslToRgb(h, s, l) {
-    if s == 0 {
-        return [l * 255, l * 255, l * 255]  // Achromatic
-    }
-    if l < 0.5 {
-        q = l * (1. + s)
-    } else {
-        q = l + s - l * s
-    }
-    p = 2. * l - q
-    r = hue2rgb(p, q, h + 1. / 3.)
-    g = hue2rgb(p, q, h)
-    b = hue2rgb(p, q, h - 1. / 3.)
-    return [int(round(r * 255)), int(round(g * 255)), int(round(b * 255))]
+// With angle as an int modulo 360 input, this gets memoized.
+func ycbr(angle) {
+	angle = PI * angle / 180.
+	// Y   Cb  Cr
+	[190, 128 + 120*sin(angle), 128 + 120*cos(angle)]
 }
 
 saturation = 1
@@ -47,21 +19,18 @@ div = 6
 
 t = 0
 now = time()
-hue = 0
-lastHue = -99
+color = [0, saturation, lightness]
 for t < 12*PI {
 	x = sin(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
 	y = cos(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
-	if t > lastHue + PI/12. { // 144 values
-		lastHue = t
-		hue = t/(12.*PI)
-		color = hslToRgb(hue, saturation, lightness)
-	}
-	image_set(imgName, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
+	// angle := int(t*180./PI) % 360 // so ycbr() get memoized with 360 values
+	// color = ycbr(angle)
+	color[0] = t/(12*PI) // hue
+	image_set_hsl(imgName, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
 	t = t + 0.0005
 }
 elapsed = time() - now
-println("Time elapsed: ", elapsed, " seconds")
+log("Time elapsed: ", elapsed, " seconds")
 
 image_save(imgName)
 

--- a/examples/image.gr
+++ b/examples/image.gr
@@ -1,0 +1,68 @@
+/* Create an image */
+
+// inspiration @shokhie
+
+func hue2rgb(p, q, t) {
+    if t < 0 {
+        t++
+    }
+    if t > 1 {
+        t--
+    }
+    if t < 1. / 6. {
+        return p + (q - p) * 6. * t
+    }
+    if t < 1. / 2. {
+        return q
+    }
+    if t < 2. / 3. {
+        return p + (q - p) * (2. / 3. - t) * 6.
+    }
+    return p
+}
+
+func hslToRgb(h, s, l) {
+    if s == 0 {
+        return [l * 255, l * 255, l * 255]  // Achromatic
+    }
+    if l < 0.5 {
+        q = l * (1. + s)
+    } else {
+        q = l + s - l * s
+    }
+    p = 2. * l - q
+    r = hue2rgb(p, q, h + 1. / 3.)
+    g = hue2rgb(p, q, h)
+    b = hue2rgb(p, q, h - 1. / 3.)
+    return [int(round(r * 255)), int(round(g * 255)), int(round(b * 255))]
+}
+
+saturation = 1
+lightness = .6
+
+size = 1024
+imgName = "canvas"
+canvas = image(imgName, size, size)
+div = 6
+
+t = 0
+now = time()
+hue = 0
+lastHue = -99
+for t < 12*PI {
+	x = sin(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
+	y = cos(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
+	if t > lastHue + PI/12. { // 144 values
+		lastHue = t
+		hue = t/(12.*PI)
+		color = hslToRgb(hue, saturation, lightness)
+	}
+	image_set(imgName, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
+	t = t + 0.0005
+}
+elapsed = time() - now
+println("Time elapsed: ", elapsed, " seconds")
+
+image_save(imgName)
+
+println("Saved image to grol.png")

--- a/examples/image.gr
+++ b/examples/image.gr
@@ -3,6 +3,8 @@
  */
 
 // inspiration @shokhie
+// See https://github.com/grol-io/grol-discord-bot/blob/main/discord.gr for a version
+// with X Y input etc... integrated with discord bot.
 
 // With angle as an int modulo 360 input, this gets memoized.
 func ycbcr(angle) {
@@ -11,8 +13,8 @@ func ycbcr(angle) {
 	[190, 128 + 120*sin(angle), 128 + 120*cos(angle)]
 }
 
-saturation = 1
-lightness = .6
+// saturation = 1
+// lightness = .6
 
 size = 1024
 imgName = "canvas"
@@ -21,7 +23,7 @@ div = 6
 
 t = 0
 now = time()
-color = [0, saturation, lightness]
+// color = [0, saturation, lightness]
 for t < 12*PI {
 	x = sin(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
 	y = cos(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))

--- a/examples/image.gr
+++ b/examples/image.gr
@@ -1,9 +1,11 @@
-/* Create an image */
+/*
+ * Create an image - very useful to use a smaller increment and run with profiling.
+ */
 
 // inspiration @shokhie
 
 // With angle as an int modulo 360 input, this gets memoized.
-func ycbr(angle) {
+func ycbcr(angle) {
 	angle = PI * angle / 180.
 	// Y   Cb  Cr
 	[190, 128 + 120*sin(angle), 128 + 120*cos(angle)]
@@ -23,10 +25,12 @@ color = [0, saturation, lightness]
 for t < 12*PI {
 	x = sin(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
 	y = cos(t) * (pow(E, cos(t)) - 2*cos(4*t) - pow(sin(t/12), 5))
-	// angle := int(t*180./PI) % 360 // so ycbr() get memoized with 360 values
-	// color = ycbr(angle)
-	color[0] = t/(12*PI) // hue
-	image_set_hsl(imgName, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
+	angle := int(t*180./PI) % 360 // so ycbr() get memoized with 360 values
+	color = ycbcr(angle)
+	image_set_ycbcr(canvas, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
+	// Or in HSL:
+	// color[0] = t/(12*PI) // hue
+	// image_set_hsl(canvas, int(size/2+(size/div)*x+0.5), int(size/2.5+(size/div)*y+0.5), color)
 	t = t + 0.0005
 }
 elapsed = time() - now

--- a/examples/prime_sequence_generator.gr
+++ b/examples/prime_sequence_generator.gr
@@ -1,0 +1,43 @@
+/* Demonstrate how to have lambdas as iterators */
+
+func primesGen(maxSieve) {
+    sieve = [true] * maxSieve
+    num = 2
+    currentPrime = 2
+    nextPrime = () => {
+        for currentPrime < len(sieve) {
+            if sieve[currentPrime] {
+                prime = currentPrime
+                currentPrime++
+                mult = prime * prime
+                for max(len(sieve) - mult, 0) {
+                    if mult % prime == 0 {
+                        sieve[mult] = false
+                    }
+                    mult++
+                }
+                return prime
+            } else {
+                currentPrime++
+            }
+        }
+        return nil
+    }
+}
+
+
+maxS = 1500
+primeIter = primesGen(maxS)
+p = primeIter()
+printf("| %4d", p)
+n = 1
+for p <= maxS {
+    p = primeIter()
+    if p != nil {
+        printf(" %4d", p)
+        if ++n % 15 == 0 {
+            print("\n|")
+        }
+    }
+}
+println()

--- a/examples/prime_sequence_generator.gr
+++ b/examples/prime_sequence_generator.gr
@@ -5,12 +5,12 @@ func primesGen(maxSieve) {
     num = 2
     currentPrime = 2
     nextPrime = () => {
-        for currentPrime < len(sieve) {
+        for currentPrime < maxSieve {
             if sieve[currentPrime] {
                 prime = currentPrime
                 currentPrime++
                 mult = prime * prime
-                for max(len(sieve) - mult, 0) {
+                for max(maxSieve - mult, 0) {
                     if mult % prime == 0 {
                         sieve[mult] = false
                     }
@@ -26,7 +26,7 @@ func primesGen(maxSieve) {
 }
 
 
-maxS = 1500
+maxS = 1000 // use 100_000 for profiling.
 primeIter = primesGen(maxS)
 p = primeIter()
 printf("| %4d", p)

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -173,6 +173,7 @@ func initInternal(c *Config) error {
 	createStrFunctions()
 	createMisc()
 	createTimeFunctions()
+	createImageFunctions()
 	return nil
 }
 

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -158,13 +158,14 @@ func initInternal(c *Config) error {
 		MaxArgs:  1,
 		ArgTypes: []object.Type{object.INTEGER},
 		Callback: func(env any, _ string, args []object.Object) object.Object {
-			eval.TriggerNoCache(env)
+			s := env.(*eval.State)
+			eval.TriggerNoCache(s)
 			if len(args) == 0 {
 				return object.Float{Value: rand.Float64()} //nolint:gosec // no need for crypto/rand here.
 			}
 			n := args[0].(object.Integer).Value
 			if n <= 0 {
-				return object.Error{Value: "argument to rand() if given must be > 0, >=2 for something useful"}
+				return s.NewError("argument to rand() if given must be > 0, >=2 for something useful")
 			}
 			return object.Integer{Value: rand.Int64N(n)} //nolint:gosec // no need for crypto/rand here.
 		},

--- a/extensions/images.go
+++ b/extensions/images.go
@@ -1,0 +1,129 @@
+package extensions
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"os"
+
+	"grol.io/grol/object"
+)
+
+type ImageMap map[object.Object]*image.RGBA
+
+// make this configurable and use the slice check as well as some sort of LRU.
+const MaxImageSize = 1024
+
+func int2RGBAColor(o object.Object) (uint8, *object.Error) {
+	if o.Type() != object.INTEGER {
+		return 0, &object.Error{Value: "color component not an integer:" + o.Inspect()}
+	}
+	i := o.(object.Integer).Value
+	if i < 0 || i > 255 {
+		return 0, &object.Error{Value: "color component out of range:" + o.Inspect()}
+	}
+	return uint8(i), nil //nolint:gosec // gosec not smart enough to see the range check just above
+}
+
+func arrayToRBGAColor(arr []object.Object) (color.RGBA, *object.Error) {
+	rgba := color.RGBA{}
+	if len(arr) < 3 || len(arr) > 4 {
+		return rgba, &object.Error{Value: "color array must have 3 or 4 elements"}
+	}
+	var oerr *object.Error
+	rgba.R, oerr = int2RGBAColor(arr[0])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	rgba.G, oerr = int2RGBAColor(arr[1])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	rgba.B, oerr = int2RGBAColor(arr[2])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	if len(arr) == 4 {
+		rgba.A, oerr = int2RGBAColor(arr[3])
+		if oerr != nil {
+			return rgba, oerr
+		}
+	} else {
+		rgba.A = 255
+	}
+	return rgba, nil
+}
+
+func createImageFunctions() {
+	cdata := make(ImageMap)
+	imgFn := object.Extension{
+		Name:       "image",
+		MinArgs:    3,
+		MaxArgs:    3,
+		Help:       "create a new image of the name and size",
+		ArgTypes:   []object.Type{object.STRING, object.INTEGER, object.INTEGER},
+		ClientData: cdata,
+		Callback: func(cdata any, _ string, args []object.Object) object.Object {
+			images := cdata.(ImageMap)
+			x := int(args[1].(object.Integer).Value)
+			y := int(args[2].(object.Integer).Value)
+			if x > MaxImageSize || y > MaxImageSize {
+				return object.Error{Value: "image size too large"}
+			}
+			if x < 0 || y < 0 {
+				return object.Error{Value: "image sizes must be positive"}
+			}
+			img := image.NewRGBA(image.Rect(0, 0, x, y))
+			transparent := color.RGBA{0, 0, 0, 0}
+			draw.Draw(img, img.Bounds(), &image.Uniform{transparent}, image.Point{}, draw.Src)
+			images[args[0]] = img
+			return args[0]
+		},
+	}
+	MustCreate(imgFn)
+	imgFn.Name = "image_set"
+	imgFn.Help = "set a pixel in the named image, color is an array of 3 or 4 elements 0-255"
+	imgFn.MinArgs = 4
+	imgFn.MaxArgs = 4
+	imgFn.ArgTypes = []object.Type{object.STRING, object.INTEGER, object.INTEGER, object.ARRAY}
+	imgFn.Callback = func(cdata any, _ string, args []object.Object) object.Object {
+		images := cdata.(ImageMap)
+		x := int(args[1].(object.Integer).Value)
+		y := int(args[2].(object.Integer).Value)
+		img, ok := images[args[0]]
+		if !ok {
+			return object.Error{Value: "image not found"}
+		}
+		color, oerr := arrayToRBGAColor(object.Elements(args[3]))
+		if oerr != nil {
+			return oerr
+		}
+		img.SetRGBA(x, y, color)
+		return args[0]
+	}
+	MustCreate(imgFn)
+	imgFn.Name = "image_save"
+	imgFn.Help = "save the named image grol.png"
+	imgFn.MinArgs = 1
+	imgFn.MaxArgs = 1
+	imgFn.ArgTypes = []object.Type{object.STRING}
+	imgFn.Callback = func(cdata any, _ string, args []object.Object) object.Object {
+		images := cdata.(ImageMap)
+		img, ok := images[args[0]]
+		if !ok {
+			return object.Error{Value: "image not found"}
+		}
+		outputFile, err := os.Create("grol.png")
+		if err != nil {
+			return object.Error{Value: "error opening image file: " + err.Error()}
+		}
+		err = png.Encode(outputFile, img)
+		if err != nil {
+			return object.Error{Value: "error encoding image: " + err.Error()}
+		}
+		outputFile.Close()
+		return args[0]
+	}
+	MustCreate(imgFn)
+}

--- a/extensions/images.go
+++ b/extensions/images.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
+	"math"
 	"os"
 
 	"grol.io/grol/object"
@@ -15,43 +16,122 @@ type ImageMap map[object.Object]*image.RGBA
 // TODO: make this configurable and use the slice check as well as some sort of LRU.
 const MaxImageDimension = 1024 // in pixels.
 
-func int2RGBAColor(o object.Object) (uint8, *object.Error) {
-	if o.Type() != object.INTEGER {
+// HSLToRGB converts HSL values to RGB.
+func HSLToRGB(h, s, l float64) color.RGBA {
+	var r, g, b float64
+
+	h = math.Mod(h, 360.) / 360.
+	s = s / 100.
+	l = l / 100.
+
+	if s == 0 {
+		r, g, b = l, l, l
+	} else {
+		var q float64
+		if l < 0.5 {
+			q = l * (1. + s)
+		} else {
+			q = l + s - l*s
+		}
+		p := 2*l - q
+		r = hueToRGB(p, q, h+1/3.)
+		g = hueToRGB(p, q, h)
+		b = hueToRGB(p, q, h-1./3.)
+	}
+
+	return color.RGBA{
+		R: uint8(math.Round(r * 255)),
+		G: uint8(math.Round(g * 255)),
+		B: uint8(math.Round(b * 255)),
+		A: 255,
+	}
+}
+func hueToRGB(p, q, t float64) float64 {
+	if t < 0 {
+		t += 1.
+	}
+	if t > 1 {
+		t -= 1.
+	}
+	if t < 1/6. {
+		return p + (q-p)*6*t
+	}
+	if t < 0.5 {
+		return q
+	}
+	if t < 2/3. {
+		return p + (q-p)*(2/3.-t)*6
+	}
+	return p
+}
+
+func elem2ColorComponent(o object.Object) (uint8, *object.Error) {
+	i := -1
+	switch o.Type() {
+	case object.FLOAT:
+		i = int(math.Round(o.(object.Float).Value))
+	case object.INTEGER:
+		i = int(o.(object.Integer).Value)
+	default:
 		return 0, &object.Error{Value: "color component not an integer:" + o.Inspect()}
 	}
-	i := o.(object.Integer).Value
 	if i < 0 || i > 255 {
 		return 0, &object.Error{Value: "color component out of range (should be 0-255):" + o.Inspect()}
 	}
 	return uint8(i), nil //nolint:gosec // gosec not smart enough to see the range check just above
 }
 
-func arrayToRBGAColor(arr []object.Object) (color.RGBA, *object.Error) {
+func rgbArrayToRBGAColor(arr []object.Object) (color.RGBA, *object.Error) {
 	rgba := color.RGBA{}
 	if len(arr) < 3 || len(arr) > 4 {
 		return rgba, &object.Error{Value: "color array must be [R,G,B] or [R,G,B,A]"}
 	}
 	var oerr *object.Error
-	rgba.R, oerr = int2RGBAColor(arr[0])
+	rgba.R, oerr = elem2ColorComponent(arr[0])
 	if oerr != nil {
 		return rgba, oerr
 	}
-	rgba.G, oerr = int2RGBAColor(arr[1])
+	rgba.G, oerr = elem2ColorComponent(arr[1])
 	if oerr != nil {
 		return rgba, oerr
 	}
-	rgba.B, oerr = int2RGBAColor(arr[2])
+	rgba.B, oerr = elem2ColorComponent(arr[2])
 	if oerr != nil {
 		return rgba, oerr
 	}
 	if len(arr) == 4 {
-		rgba.A, oerr = int2RGBAColor(arr[3])
+		rgba.A, oerr = elem2ColorComponent(arr[3])
 		if oerr != nil {
 			return rgba, oerr
 		}
 	} else {
 		rgba.A = 255
 	}
+	return rgba, nil
+}
+
+func ycbrArrayToRBGAColor(arr []object.Object) (color.RGBA, *object.Error) {
+	rgba := color.RGBA{}
+	ycbcr := color.YCbCr{}
+	if len(arr) != 3 {
+		return rgba, &object.Error{Value: "color array must be [Y',Cb,Cr]"}
+	}
+	var oerr *object.Error
+	ycbcr.Y, oerr = elem2ColorComponent(arr[0])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	ycbcr.Cb, oerr = elem2ColorComponent(arr[1])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	ycbcr.Cr, oerr = elem2ColorComponent(arr[2])
+	if oerr != nil {
+		return rgba, oerr
+	}
+	rgba.A = 255
+	rgba.R, rgba.G, rgba.B = color.YCbCrToRGB(ycbcr.Y, ycbcr.Cb, ycbcr.Cr)
+	// return color.YCbCrModel.Convert(ycbcr).(color.RGBA), nil
 	return rgba, nil
 }
 
@@ -62,7 +142,7 @@ func createImageFunctions() {
 		Name:       "image",
 		MinArgs:    3,
 		MaxArgs:    3,
-		Help:       "create a new image of the name and size",
+		Help:       "create a new RGBA image of the name and size, image starts entirely transparent",
 		ArgTypes:   []object.Type{object.STRING, object.INTEGER, object.INTEGER},
 		ClientData: cdata,
 		Callback: func(cdata any, _ string, args []object.Object) object.Object {
@@ -84,11 +164,11 @@ func createImageFunctions() {
 	}
 	MustCreate(imgFn)
 	imgFn.Name = "image_set"
-	imgFn.Help = "set a pixel in the named image, color is an array of 3 or 4 elements 0-255"
+	imgFn.Help = "img, x, y, color: set a pixel in the named image, color is an array of 3 or 4 elements 0-255"
 	imgFn.MinArgs = 4
 	imgFn.MaxArgs = 4
 	imgFn.ArgTypes = []object.Type{object.STRING, object.INTEGER, object.INTEGER, object.ARRAY}
-	imgFn.Callback = func(cdata any, _ string, args []object.Object) object.Object {
+	imgFn.Callback = func(cdata any, name string, args []object.Object) object.Object {
 		images := cdata.(ImageMap)
 		x := int(args[1].(object.Integer).Value)
 		y := int(args[2].(object.Integer).Value)
@@ -96,13 +176,23 @@ func createImageFunctions() {
 		if !ok {
 			return object.Error{Value: "image not found"}
 		}
-		color, oerr := arrayToRBGAColor(object.Elements(args[3]))
+		colorArray := object.Elements(args[3])
+		var color color.RGBA
+		var oerr *object.Error
+		if name == "image_set_ycbcr" {
+			color, oerr = ycbrArrayToRBGAColor(colorArray)
+		} else {
+			color, oerr = rgbArrayToRBGAColor(colorArray)
+		}
 		if oerr != nil {
 			return oerr
 		}
 		img.SetRGBA(x, y, color)
 		return args[0]
 	}
+	MustCreate(imgFn)
+	imgFn.Name = "image_set_ycbcr"
+	imgFn.Help = "img, x, y, color: set a pixel in the named image, color Y'CbCr in an array of 3 elements 0-255"
 	MustCreate(imgFn)
 	imgFn.Name = "image_save"
 	imgFn.Help = "save the named image grol.png"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module grol.io/grol
 
-go 1.22.6
+go 1.22.7
+
+toolchain go1.22.7
 
 require (
 	fortio.org/cli v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module grol.io/grol
 
 go 1.22.7
 
-toolchain go1.22.7
-
 require (
 	fortio.org/cli v1.9.0
 	fortio.org/log v1.16.0

--- a/object/object.go
+++ b/object/object.go
@@ -498,6 +498,17 @@ type Error struct {
 	Stack []string
 }
 
+// Use eval's Errorf() instead whenever possible, to get the stack.
+// This one should only be used by extensions that do not take the state as clientdata.
+func Errorf(format string, args ...interface{}) Error {
+	return Error{Value: fmt.Sprintf(format, args...)}
+}
+
+// Pointer version of Errorf. used in code conditionally returning an error (oerr pointer).
+func Errorfp(format string, args ...interface{}) *Error {
+	return &Error{Value: fmt.Sprintf(format, args...)}
+}
+
 func (e Error) JSON(w io.Writer) error {
 	_, err := fmt.Fprintf(w, `{"err":%q}`, e.Value)
 	return err

--- a/object/object.go
+++ b/object/object.go
@@ -1056,7 +1056,9 @@ type Reference struct {
 }
 
 func (r Reference) Value() Object {
-	log.Debugf("Reference Value() %s -> %s", r.Name, r.RefEnv.store[r.Name].Inspect())
+	if log.LogDebug() {
+		log.Debugf("Reference Value() %s -> %s", r.Name, r.RefEnv.store[r.Name].Inspect())
+	}
 	v := r.RefEnv.store[r.Name]
 	if v == r {
 		panic("Self reference")

--- a/object/state.go
+++ b/object/state.go
@@ -189,7 +189,9 @@ func (e *Environment) makeRef(name string) (*Reference, bool) {
 			ref = r // set and return the original ref instead of ref of ref.
 		}
 		orig.store[name] = ref
-		orig.getMiss++ // creating a ref is a miss.
+		if !Constant(name) {
+			orig.getMiss++ // creating a ref to a non constant is a miss.
+		}
 		return &ref, true
 	}
 	return nil, false
@@ -201,7 +203,8 @@ func (e *Environment) Get(name string) (Object, bool) {
 	}
 	obj, ok := e.store[name]
 	if ok {
-		if _, ok = obj.(Reference); ok { // using references implies uncacheable.
+		// using references to non constant (extensions are constants) implies uncacheable.
+		if r, ok := obj.(Reference); ok && !Constant(r.Name) {
 			e.getMiss++
 		}
 		return obj, true


### PR DESCRIPTION
./grol examples/image.gr

Produces

Time elapsed:  0.6636569499969482  seconds
Saved image to grol.png


![grol](https://github.com/user-attachments/assets/5d5f4e35-01c2-46e0-a46b-3375dd860ffd)
