### PR TITLE
Tweak api and comment to make it clear cancel() must be called. Also add debounce() to wasm run()

### DIFF
--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -111,17 +111,21 @@ func (s *State) UpdateNumSet() (oldvalue, newvalue int64) {
 	return
 }
 
-func (s *State) SetContext(ctx context.Context, d time.Duration) {
+// SetContext sets the context for the evaluator, with a maximum duration.
+// The returned cancel function can be used to cancel the context sooner and must be
+// called (in a defer typically) to release resources (to avoid issue #204).
+func (s *State) SetContext(ctx context.Context, d time.Duration) context.CancelFunc {
 	if d <= 0 {
 		log.LogVf("SetContext with unlimited duration")
 		s.Context, s.Cancel = context.WithCancel(ctx)
 	} else {
 		s.Context, s.Cancel = context.WithTimeout(ctx, d)
 	}
+	return s.Cancel
 }
 
-func (s *State) SetDefaultContext() {
-	s.SetContext(context.Background(), DefaultMaxDuration)
+func (s *State) SetDefaultContext() context.CancelFunc {
+	return s.SetContext(context.Background(), DefaultMaxDuration)
 }
 
 // Does unwrap (so stop bubbling up) return values.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -379,8 +379,8 @@ func EvalOne(ctx context.Context, s *eval.State, what string, out io.Writer, opt
 			}
 		}()
 	}
-	s.SetContext(ctx, options.MaxDuration)
-	defer s.Cancel()
+	cancel := s.SetContext(ctx, options.MaxDuration)
+	defer cancel() // must be called to avoid leaking timeout context, which caused #204.
 	continuation, errs, formatted = evalOne(s, what, out, options)
 	return
 }

--- a/wasm/grol_wasm.html
+++ b/wasm/grol_wasm.html
@@ -38,6 +38,14 @@
 </style>
 <script src="wasm_exec.js"></script>
 <script>
+    function debounce(func) {
+        let timeout
+        return function (...args) {
+            const context = this
+            clearTimeout(timeout)
+            timeout = setTimeout(() => func.apply(context, args), 100) // 100ms debounce
+        }
+    }
     if (!WebAssembly.instantiateStreaming) { // polyfill
         WebAssembly.instantiateStreaming = async (resp, importObject) => {
             const source = await (await resp).arrayBuffer();
@@ -106,10 +114,11 @@
         resizeTextarea(document.getElementById('output'));
         resizeTextarea(document.getElementById('errors'));
     }
+    const debounceRun = debounce(run)
     document.addEventListener('DOMContentLoaded', (event) => {
         document.getElementById('input').addEventListener('keydown', function (e) {
             if (e.key === 'Enter' && !isRunning) {
-                run();
+                debounceRun();
             }
         });
     });
@@ -133,7 +142,8 @@ a=[fact(5), "abc", sqrt(2)] // heterogeneous array, math functions
 m={"str key": a, PI: "pi", 42: "str val", 1e3: "a lot"}</textarea>
 </div>
 <div>
-    Hit enter or click <button onClick="run();" id="runButton" disabled>Run</button> (will also format the code, also
+    Hit enter or click <button onClick="debounceRun()" id="runButton" disabled>Run</button> (will also format the code,
+    also
     try <input type="checkbox" id="compact">compact)
     <button id="addParamButton">Share</button>
     <script>


### PR DESCRIPTION
Only on chrome (not on safari) clicking run a few times with the body being for instance `sleep(0.5)` would get back to #204  state after the last run, this debounce _hides_ this (not fixes it... imo)
