### PR TITLE
Copy when ast.Modify() so expanding macros expand each macro use as the right one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ wasm/wasm_exec.html:
 test: grol
 	CGO_ENABLED=0 go test -tags $(GO_BUILD_TAGS) ./...
 	GOMEMLIMIT=1GiB ./grol examples/*.gr
-	GOMEMLIMIT=1GiB ./grol grol_tests/*.gr
+	GOMEMLIMIT=1GiB ./grol -shared-state grol_tests/*.gr
 
 check: grol
 	./check_samples_double_format.sh examples/*.gr

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -3,7 +3,7 @@ package ast
 import "fmt"
 
 // Note, this is somewhat similar to eval.go's eval... both are "apply"ing.
-func Modify(node Node, f func(Node) Node) Node { //nolint:funlen // yeah lots of types.
+func Modify(node Node, f func(Node) Node) Node { //nolint:funlen,gocyclo // yeah lots of types.
 	// TODO: add err checks for _s.
 	switch node := node.(type) {
 	case *Statements:

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -1,55 +1,121 @@
 package ast
 
-import "fortio.org/log"
+import (
+	"fortio.org/log"
+)
 
 // Note, this is somewhat similar to eval.go's eval... both are "apply"ing.
-func Modify(node Node, f func(Node) Node) Node {
+func Modify(node Node, f func(Node) Node) Node { //nolint:funlen // yeah lots of types.
 	// TODO: add err checks for _s.
 	switch node := node.(type) {
 	case *Statements:
+		newNode := &Statements{Base: node.Base, Statements: make([]Node, len(node.Statements))}
 		for i, statement := range node.Statements {
-			node.Statements[i] = Modify(statement, f)
+			newNode.Statements[i] = Modify(statement, f)
 		}
+		return f(newNode)
 	case *InfixExpression:
-		le := Modify(node.Left, f)
-		node.Left = le
-		re := Modify(node.Right, f)
-		node.Right = re
+		newNode := &InfixExpression{Base: node.Base}
+		newNode.Left = Modify(node.Left, f)
+		newNode.Right = Modify(node.Right, f)
+		return f(newNode)
 	case *PrefixExpression:
-		pe := Modify(node.Right, f)
-		node.Right = pe
+		newNode := &PrefixExpression{Base: node.Base}
+		newNode.Right = Modify(node.Right, f)
+		return f(newNode)
 	case *IndexExpression:
-		node.Left = Modify(node.Left, f)
-		node.Index = Modify(node.Index, f)
+		newNode := &IndexExpression{Base: node.Base}
+		newNode.Left = Modify(node.Left, f)
+		newNode.Index = Modify(node.Index, f)
+		return f(newNode)
 	case *IfExpression:
-		ce := Modify(node.Condition, f)
-		node.Condition = ce
-		node.Consequence = Modify(node.Consequence, f).(*Statements)
+		newNode := &IfExpression{Base: node.Base}
+		newNode.Condition = Modify(node.Condition, f)
+		newNode.Consequence = Modify(node.Consequence, f).(*Statements)
 		if node.Alternative != nil {
-			node.Alternative = Modify(node.Alternative, f).(*Statements)
+			newNode.Alternative = Modify(node.Alternative, f).(*Statements)
 		}
+		return f(newNode)
+	case *ForExpression:
+		newNode := &ForExpression{Base: node.Base}
+		newNode.Condition = Modify(node.Condition, f)
+		newNode.Body = Modify(node.Body, f).(*Statements)
+		return f(newNode)
 	case *ReturnStatement:
-		re := Modify(node.ReturnValue, f)
-		node.ReturnValue = re
+		newNode := &ReturnStatement{Base: node.Base}
+		newNode.ReturnValue = Modify(node.ReturnValue, f)
+		return f(newNode)
 	case *FunctionLiteral:
+		newNode := *node
+		newNode.Parameters = make([]Node, len(node.Parameters))
 		for i := range node.Parameters {
-			node.Parameters[i] = Modify(node.Parameters[i], f).(*Identifier)
+			newNode.Parameters[i] = Modify(node.Parameters[i], f).(*Identifier)
 		}
-		node.Body = Modify(node.Body, f).(*Statements)
+		newNode.Body = Modify(node.Body, f).(*Statements)
+		return f(&newNode)
 	case *ArrayLiteral:
+		newNode := &ArrayLiteral{Base: node.Base, Elements: make([]Node, len(node.Elements))}
 		for i := range node.Elements {
-			node.Elements[i] = Modify(node.Elements[i], f)
+			newNode.Elements[i] = Modify(node.Elements[i], f)
 		}
+		return f(newNode)
 	case *MapLiteral:
-		newPairs := make(map[Node]Node)
-		for key, val := range node.Pairs {
+		newNode := &MapLiteral{Base: node.Base, Pairs: make(map[Node]Node)}
+		for _, key := range node.Order {
+			val := node.Pairs[key]
 			newKey := Modify(key, f)
-			newVal := Modify(val, f)
-			newPairs[newKey] = newVal // TODO: bug, change Order too.
+			newNode.Order = append(newNode.Order, newKey)
+			newNode.Pairs[newKey] = Modify(val, f)
 		}
-		node.Pairs = newPairs
+		return f(newNode)
+	case *Identifier:
+		n := *node
+		return f(&n) // silly go optimizes &(*node) to node (ptr) so need 2 steps
+	case *IntegerLiteral:
+		n := *node
+		return f(&n)
+	case *FloatLiteral:
+		n := *node
+		return f(&n)
+	case *StringLiteral:
+		n := *node
+		return f(&n)
+	case *Boolean:
+		n := *node
+		return f(&n)
+	case *Comment:
+		n := *node
+		return f(&n)
+	case *ControlExpression:
+		n := *node
+		return f(&n)
+	case *PostfixExpression:
+		n := *node
+		return f(&n)
+	case *Builtin:
+		newNode := &Builtin{Base: node.Base, Parameters: make([]Node, len(node.Parameters))}
+		for i := range node.Parameters {
+			newNode.Parameters[i] = Modify(node.Parameters[i], f)
+		}
+		return f(newNode)
+	case *CallExpression:
+		newNode := *node
+		newNode.Arguments = make([]Node, len(node.Arguments))
+		for i := range node.Arguments {
+			newNode.Arguments[i] = Modify(node.Arguments[i], f)
+		}
+		return f(&newNode)
+	case *MacroLiteral:
+		// modifying macro itself may be pointless but for completeness.
+		newNode := *node
+		newNode.Parameters = make([]Node, len(node.Parameters))
+		for i := range node.Parameters {
+			newNode.Parameters[i] = Modify(node.Parameters[i], f).(*Identifier)
+		}
+		newNode.Body = Modify(node.Body, f).(*Statements)
+		return f(&newNode)
 	default:
-		log.LogVf("default for node type %T", node)
+		log.Warnf("default for node type %T", node)
 	}
 	return f(node)
 }

--- a/ast/modify_test.go
+++ b/ast/modify_test.go
@@ -102,14 +102,20 @@ func TestModify(t *testing.T) {
 			&ArrayLiteral{Elements: []Node{two(), two()}},
 		},
 		{
-			&MapLiteral{Pairs: map[Node]Node{
-				one(): one(),
-				one(): one(),
-			}},
-			&MapLiteral{Pairs: map[Node]Node{
-				two(): two(),
-				two(): two(),
-			}},
+			&MapLiteral{
+				Pairs: map[Node]Node{
+					one(): one(),
+					two(): one(),
+				},
+				Order: []Node{two(), one()},
+			},
+			&MapLiteral{
+				Pairs: map[Node]Node{
+					two(): two(),
+					two(): two(),
+				},
+				Order: []Node{two(), two()}, // kinda bogus.
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/ast/modify_test.go
+++ b/ast/modify_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 )
 
-func TestModify(t *testing.T) {
-	one := func() Node { return IntegerLiteral{Val: 1} }
-	two := func() Node { return IntegerLiteral{Val: 2} }
+var (
+	one  = func() Node { return &IntegerLiteral{Val: 1} }
+	two  = func() Node { return &IntegerLiteral{Val: 2} }
+	aone = one()
+	atwo = two()
 
-	turnOneIntoTwo := func(node Node) Node {
-		integer, ok := node.(IntegerLiteral)
+	turnOneIntoTwo = func(node Node) Node {
+		integer, ok := node.(*IntegerLiteral)
 		if !ok {
 			return node
 		}
@@ -22,7 +24,9 @@ func TestModify(t *testing.T) {
 		integer.Val = 2
 		return integer
 	}
+)
 
+func TestModify(t *testing.T) {
 	tests := []struct {
 		input    Node
 		expected Node
@@ -101,27 +105,37 @@ func TestModify(t *testing.T) {
 			&ArrayLiteral{Elements: []Node{one(), one()}},
 			&ArrayLiteral{Elements: []Node{two(), two()}},
 		},
-		{
-			&MapLiteral{
-				Pairs: map[Node]Node{
-					one(): one(),
-					two(): one(),
-				},
-				Order: []Node{two(), one()},
-			},
-			&MapLiteral{
-				Pairs: map[Node]Node{
-					two(): two(),
-					two(): two(),
-				},
-				Order: []Node{two(), two()}, // kinda bogus.
-			},
-		},
 	}
 	for _, tt := range tests {
 		modified := Modify(tt.input, turnOneIntoTwo)
 		if !reflect.DeepEqual(modified, tt.expected) {
 			t.Errorf("not equal.\n%#v\n-vs-\n%#v", modified, tt.expected)
+		}
+	}
+}
+
+func TestModifyMap(t *testing.T) {
+	// need to test map separately because deepequal can't compare a map
+	// with keys of the same underlying value (2:2, 2:2)
+	modified := Modify(
+		&MapLiteral{
+			Pairs: map[Node]Node{
+				aone: one(),
+				atwo: one(),
+			},
+			Order: []Node{atwo, aone},
+		}, turnOneIntoTwo).(*MapLiteral)
+	if len(modified.Order) != 2 {
+		t.Errorf("Order length not 2. got=%d", len(modified.Order))
+	}
+	for i := range 2 {
+		key := modified.Order[i]
+		if key.(*IntegerLiteral).Val != 2 {
+			t.Errorf("Order[%d] not 2. got=%v", i, modified.Order[i])
+		}
+		val := modified.Pairs[key]
+		if val.(*IntegerLiteral).Val != 2 {
+			t.Errorf("Pairs not modified for key %v -> %v", key, val)
 		}
 	}
 }

--- a/eval/eval_api.go
+++ b/eval/eval_api.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"fortio.org/log"
+	"grol.io/grol/ast"
 	"grol.io/grol/lexer"
 	"grol.io/grol/object"
 	"grol.io/grol/parser"
@@ -170,7 +171,8 @@ func AddEvalResult(name, code string) error {
 func EvalString(this any, code string, emptyEnv bool) (object.Object, error) {
 	l := lexer.New(code)
 	p := parser.New(l)
-	program := p.ParseProgram()
+	var program ast.Node
+	program = p.ParseProgram()
 	if len(p.Errors()) != 0 {
 		return object.NULL, fmt.Errorf("parsing error: %v", p.Errors())
 	}
@@ -187,7 +189,7 @@ func EvalString(this any, code string, emptyEnv bool) (object.Object, error) {
 			return object.NULL, fmt.Errorf("invalid this: %T", this)
 		}
 		evalState.DefineMacros(program)
-		_ = evalState.ExpandMacros(program)
+		program = evalState.ExpandMacros(program)
 	}
 	res := evalState.Eval(program)
 	if res.Type() == object.ERROR {

--- a/eval/macro_expension.go
+++ b/eval/macro_expension.go
@@ -9,7 +9,8 @@ import (
 	"grol.io/grol/token"
 )
 
-func (s *State) DefineMacros(program *ast.Statements) {
+func (s *State) DefineMacros(programNode ast.Node) {
+	program := programNode.(*ast.Statements) // panic if not a program is ok.
 	for i := 0; i < len(program.Statements); /* not always incrementing */ {
 		statement := program.Statements[i]
 		if isMacroDefinition(statement) {

--- a/eval/macro_expension_test.go
+++ b/eval/macro_expension_test.go
@@ -95,13 +95,13 @@ func TestExpandMacros(t *testing.T) {
             `,
 			`(1 + 2)`,
 		},
-		{
+		{ // bug where first macro use is all of them. #223.
 			`
-            reverse = macro(a, b) { quote(unquote(b) - unquote(a)); };
-
-            reverse(2 + 2, 10 - 5);
+            reverse = macro(a, b) { quote(unquote(b) - unquote(a)) }
+            reverse(x,y)
+            reverse(2 + 2, 10 - 5)
             `,
-			`(10 - 5) - (2 + 2)`,
+			`(y-x) (10 - 5) - (2 + 2)`,
 		},
 		{
 			`

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -313,7 +313,7 @@ func Interactive(options Options) int { //nolint:funlen // we do have quite a fe
 type Grol struct {
 	State     *eval.State
 	PrintEval bool
-	program   *ast.Statements
+	program   ast.Node
 }
 
 // Initialize with new empty state.
@@ -335,9 +335,7 @@ func (g *Grol) Parse(inp []byte) error {
 		return nil
 	}
 	log.LogVf("Expanding, %d macros defined", numMacros)
-	// This actually modifies the original program, not sure... that's good but that's why
-	// expanded return value doesn't need to be used.
-	_ = g.State.ExpandMacros(g.program)
+	g.program = g.State.ExpandMacros(g.program)
 	return nil
 }
 
@@ -393,7 +391,8 @@ func evalOne(s *eval.State, what string, out io.Writer, options Options) (bool, 
 		l = lexer.NewLineMode(what)
 	}
 	p := parser.New(l)
-	program := p.ParseProgram()
+	var program ast.Node
+	program = p.ParseProgram()
 	if logParserErrors(p) {
 		return false, p.Errors(), what
 	}
@@ -428,9 +427,7 @@ func evalOne(s *eval.State, what string, out io.Writer, options Options) (bool, 
 	numMacros := s.NumMacros()
 	if numMacros > 0 {
 		log.LogVf("Expanding, %d macros defined", numMacros)
-		// This actually modifies the original program, not sure... that's good but that's why
-		// expanded return value doesn't need to be used.
-		_ = s.ExpandMacros(program)
+		program = s.ExpandMacros(program)
 		if options.ShowParse {
 			fmt.Fprint(out, "== Macro ==> ")
 			program.PrettyPrint(&ast.PrintState{Out: out})


### PR DESCRIPTION
Fixes:
- #20 
- #223 
- #68

Was a pretty bad bug and #20 was a smoking gun, so where the comments I then wrote in the code
(basically that macros would only work properly "once")
