### PR TITLE
Make division same precedence as multiplication for left to right conversion without parenthesis

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -24,8 +24,7 @@ const (
 	EQUALS      // ==
 	LESSGREATER // > or <
 	SUM         // +
-	PRODUCT     // *
-	DIVIDE      // /
+	PRODUCT     // * // removed DIVIDE // / // we do want left to right so 1.*2/3 is 0.6666666666666666 not 0
 	PREFIX      // -X or !X
 	CALL        // myFunction(X)
 	INDEX       // array[index]
@@ -54,7 +53,7 @@ var Precedences = map[token.Type]Priority{
 	token.PERCENT:    PRODUCT,
 	token.LEFTSHIFT:  PRODUCT,
 	token.RIGHTSHIFT: PRODUCT,
-	token.SLASH:      DIVIDE,
+	token.SLASH:      PRODUCT, // was DIVIDE
 	token.INCR:       PREFIX,
 	token.DECR:       PREFIX,
 	token.LPAREN:     CALL,

--- a/ast/priority_string.go
+++ b/ast/priority_string.go
@@ -17,16 +17,15 @@ func _() {
 	_ = x[LESSGREATER-7]
 	_ = x[SUM-8]
 	_ = x[PRODUCT-9]
-	_ = x[DIVIDE-10]
-	_ = x[PREFIX-11]
-	_ = x[CALL-12]
-	_ = x[INDEX-13]
-	_ = x[DOTINDEX-14]
+	_ = x[PREFIX-10]
+	_ = x[CALL-11]
+	_ = x[INDEX-12]
+	_ = x[DOTINDEX-13]
 }
 
-const _Priority_name = "LOWESTASSIGNORANDLAMBDAEQUALSLESSGREATERSUMPRODUCTDIVIDEPREFIXCALLINDEXDOTINDEX"
+const _Priority_name = "LOWESTASSIGNORANDLAMBDAEQUALSLESSGREATERSUMPRODUCTPREFIXCALLINDEXDOTINDEX"
 
-var _Priority_index = [...]uint8{0, 6, 12, 14, 17, 23, 29, 40, 43, 50, 56, 62, 66, 71, 79}
+var _Priority_index = [...]uint8{0, 6, 12, 14, 17, 23, 29, 40, 43, 50, 56, 60, 65, 73}
 
 func (i Priority) String() string {
 	i -= 1

--- a/grol_tests/precedence.gr
+++ b/grol_tests/precedence.gr
@@ -1,0 +1,12 @@
+
+
+num := 2
+div := 3
+
+r := 1. * num / div
+
+if r != 2./3. {
+	error("FAIL division was integer division instead of 1.* converting to float")
+} else {
+	println("OK division was float division", r)
+}


### PR DESCRIPTION
except that breaks the simplification code (which must preserve parens for say

1./(a*b) to not turn into 1./a*b