### PR TITLE
Make info.globals a map so it's easy to check info.globals.foo if foo is defined - removed all_ids, replaced by globals+stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ $ m=fact(7)
 $ m/n
 == Parse ==> m / n
 == Eval  ==> 7
-$ func fx(n) {if n>0 {return fx(n-1)}; info.all_ids}; fx(3)
-== Parse ==> func fx(n) {
+$ func fx(n,s) {if n>0 {return fx(n-1,s)}; info.stack}; fx(3,"abc")
+== Parse ==> func fx(n, s) {
 	if n > 0 {
-		return fx(n - 1)
+		return fx(n - 1, s)
 	}
-	info.all_ids
+	info.stack
 }
-fx(3)
-== Eval  ==> {0:["E","PI","abs","fact","fx","log2","n","printf"],1:["n","self"],2:["fx","n","self"],3:["fx","n","self"],4:["fx","n","self"]}
+fx(3, "abc")
+== Eval  ==> [{"s":true},{"s":true},{"s":true},{"s":true}] // registers don't show up, so only s does and not n	
 $ info["gofuncs"] // other way to access map keys, for when they aren't strings for instance
 == Parse ==> info["gofuncs"] // other way to access map keys, for when they aren't strings for instance
 == Eval  ==> ["acos","asin","atan","ceil","cos","eval","exp","floor","json","ln","log10","pow","round","sin","sprintf","sqrt","tan","trunc","unjson"]

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -146,7 +146,7 @@ func TestEvalBooleanExpression(t *testing.T) {
 		{"(1 > 2) == false", true},
 		{`"hello" == "world"`, false},
 		{`"hello" == "hello"`, true},
-		{`info["all_ids"] == info.all_ids`, true},
+		{`info["globals"] == info.globals`, true},
 	}
 
 	for _, tt := range tests {

--- a/main_test.txtar
+++ b/main_test.txtar
@@ -121,8 +121,8 @@ stdout '^3$'
 !stderr .
 
 # eval() runs in the same context as when called
-grol -quiet -c 'func foo(x) {eval("info")};foo("A")["all_ids"][1]'
-stdout '^\["x"\]$'
+grol -quiet -c 'func foo(x) {eval("info")};foo("A")["stack"][0]'
+stdout '^{"x":true}$'
 !stderr .
 
 # json of (nested) arrays

--- a/object/state.go
+++ b/object/state.go
@@ -56,7 +56,7 @@ func (e *Environment) BaseInfo() *BigMap {
 	if baseInfo.kv != nil {
 		return &baseInfo
 	}
-	baseInfo.kv = make([]keyValuePair, 0, 7) // 6 here + all_ids
+	baseInfo.kv = make([]keyValuePair, 0, 8) // 6 here + globals + stack
 	tokInfo := token.Info()
 	keys := make([]Object, 0, len(tokInfo.Keywords))
 	for _, v := range sets.Sort(tokInfo.Keywords) {
@@ -88,7 +88,8 @@ func (e *Environment) BaseInfo() *BigMap {
 }
 
 func (e *Environment) Info() Object {
-	allKeys := make([]Object, e.depth+1)
+	allKeys := make([]Object, e.depth)
+	info := e.BaseInfo()
 	for {
 		keys := make([]string, 0, len(e.store))
 		for k := range e.store {
@@ -97,16 +98,20 @@ func (e *Environment) Info() Object {
 		slices.Sort(keys)
 		set := NewMapSize(len(keys))
 		for _, k := range keys {
-			set.Set(String{Value: k}, TRUE)
+			set = set.Set(String{Value: k}, TRUE)
 		}
-		allKeys[e.depth] = set
+		log.LogVf("Info() for %d - %d - keys %v set %v", e.depth, len(e.store), keys, set)
+		if e.depth == 0 {
+			info.Set(String{"globals"}, set) // 0 == globals
+		} else {
+			allKeys[e.depth-1] = set
+		}
 		if e.outer == nil {
 			break
 		}
 		e = e.outer
 	}
-	info := e.BaseInfo()
-	info.Set(String{"all_ids"}, BigArray{elements: allKeys}) // 7
+	info.Set(String{"stack"}, NewArray(allKeys))
 	return info
 }
 
@@ -228,6 +233,7 @@ func (e *Environment) makeRef(name string) (*Reference, bool) {
 
 func (e *Environment) Get(name string) (Object, bool) {
 	if name == "info" {
+		e.TriggerNoCache()
 		return e.Info(), true
 	}
 	if name == "self" {

--- a/object/state.go
+++ b/object/state.go
@@ -95,11 +95,11 @@ func (e *Environment) Info() Object {
 			keys = append(keys, k)
 		}
 		slices.Sort(keys)
-		arr := MakeObjectSlice(len(keys))
+		set := NewMapSize(len(keys))
 		for _, k := range keys {
-			arr = append(arr, String{Value: k})
+			set.Set(String{Value: k}, TRUE)
 		}
-		allKeys[e.depth] = NewArray(arr)
+		allKeys[e.depth] = set
 		if e.outer == nil {
 			break
 		}

--- a/tests/conversions.gr
+++ b/tests/conversions.gr
@@ -29,3 +29,12 @@ Assert("int() with trim() whitespaces work", int(trim("\n  123\n\t")) == 123)
 Assert("int(\"0\") is 0", int("0") == 0)
 Assert("int(\"0xa\") is 10", int("0xa") == 10)           // hex still working despite leading 0 handling
 Assert("int(\"0755\") octal is 493", int("0755") == 493) // octal still working despite leading 0 handling
+
+// Unrelated for small test for existence of stuff
+func Exists(x) {
+	// log(info.globals)
+	info.globals[x] == true
+}
+Assert("exists false before we set foo", Exists("foo") == false)
+foo=42
+Assert("exists true after we set foo", Exists("foo") == true)


### PR DESCRIPTION
Fixes #299 