### PR TITLE
Fixing memoization of lambda/functions being returned (capturing state)

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -741,6 +741,13 @@ func (s *State) applyFunction(name string, fn object.Object, args []object.Objec
 		log.Debugf("Cache miss for %s %v, not caching error result", function.CacheKey, args)
 		return res
 	}
+	// Don't cache if the result is a function that captures state
+	if res.Type() == object.FUNC {
+		if resFn, ok := res.(object.Function); ok && resFn.Lambda && resFn.Env != nil {
+			log.Debugf("Cache miss for %s %v, not caching lambda with captured state", function.CacheKey, args)
+			return res
+		}
+	}
 	s.cache.Set(function.CacheKey, args, res, output)
 	log.Debugf("Cache miss for %s %v", function.CacheKey, args)
 	return res

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -743,10 +743,9 @@ func (s *State) applyFunction(name string, fn object.Object, args []object.Objec
 	}
 	// Don't cache if the result is a function that captures state
 	if res.Type() == object.FUNC {
-		if resFn, ok := res.(object.Function); ok && resFn.Lambda && resFn.Env != nil {
-			log.Debugf("Cache miss for %s %v, not caching lambda with captured state", function.CacheKey, args)
-			return res
-		}
+		log.Debugf("Cache miss for %s %v, not caching function returned", function.CacheKey, args)
+		s.env.TriggerNoCache()
+		return res
 	}
 	s.cache.Set(function.CacheKey, args, res, output)
 	log.Debugf("Cache miss for %s %v", function.CacheKey, args)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -741,7 +741,7 @@ func (s *State) applyFunction(name string, fn object.Object, args []object.Objec
 		log.Debugf("Cache miss for %s %v, not caching error result", function.CacheKey, args)
 		return res
 	}
-	// Don't cache if the result is a function that captures state
+	// TODO: reduce scope of not caching to a function that captures state (#358)
 	if res.Type() == object.FUNC {
 		log.Debugf("Cache miss for %s %v, not caching function returned", function.CacheKey, args)
 		s.env.TriggerNoCache()

--- a/tests/misc.gr
+++ b/tests/misc.gr
@@ -43,6 +43,28 @@ emptylambda = () => {}
 
 emptylambda()
 
+
+// Memoization issue #358
+func w(n) {
+	state := n
+	.. => {
+		if len(..) == 0 {
+			state
+		} else {
+			state = ..[0]
+		}
+	}
+}
+n = 1
+u = w(n)
+v = w(n)
+u(2)
+v(3)
+log("u=", u())
+log("v=", v())
+Assert("memoization issue v is 3", v() == 3)
+Assert("memoization issue u shouldn't be 3, should be 2", u() == 2)
+
 // Test boolean values in lambda functions and dereferencing
 // Basic lambda with boolean
 func g(x) {func f() {if x {1} else {2}}; f()}
@@ -54,8 +76,7 @@ func h(x) {func f() {func g() {if x {1} else {2}}; g()}; f()}
 log("h=",h(true))
 Assert("boolean in nested lambda", h(true) == 1)
 log("h=",h(false))
-// BUG TODO/FIXME: g() inside f() is getting memoized/cached when it shouldn't be
-// Assert("boolean in nested lambda false", h(false) == 2)
+Assert("boolean in nested lambda false", h(false) == 2)
 
 // Lambda with boolean in for loop
 func i(x) {func f() {for x {return 1}; return 2}; f()}

--- a/tests/misc.gr
+++ b/tests/misc.gr
@@ -76,7 +76,7 @@ func h(x) {func f() {func g() {if x {1} else {2}}; g()}; f()}
 log("h=",h(true))
 Assert("boolean in nested lambda", h(true) == 1)
 log("h=",h(false))
-// BUG TODO/FIXME: h(false) is getting memoized/cached when it shouldn't be
+// BUG TODO/FIXME: g() inside f() is getting memoized/cached when it shouldn't be
 // Assert("boolean in nested lambda false", h(false) == 2)
 
 // Lambda with boolean in for loop

--- a/tests/misc.gr
+++ b/tests/misc.gr
@@ -76,7 +76,8 @@ func h(x) {func f() {func g() {if x {1} else {2}}; g()}; f()}
 log("h=",h(true))
 Assert("boolean in nested lambda", h(true) == 1)
 log("h=",h(false))
-Assert("boolean in nested lambda false", h(false) == 2)
+// BUG TODO/FIXME: h(false) is getting memoized/cached when it shouldn't be
+// Assert("boolean in nested lambda false", h(false) == 2)
 
 // Lambda with boolean in for loop
 func i(x) {func f() {for x {return 1}; return 2}; f()}


### PR DESCRIPTION
- [x] failing test
- [x] fix
- [ ] check memoization still work elsewhere

Unfortunately this isn't very smart ie it will prevent memoization of anything that calls something that returns a function
And yet doesn't fix #360 but it's progress for now

Fixes #358 