### PR TITLE
Disallow `del(CONSTANT)`

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -463,6 +463,9 @@ func (s *State) evalDelete(node ast.Node) object.Object {
 		if name == "" {
 			return s.NewError("delete empty identifier")
 		}
+		if object.Constant(name) {
+			return s.NewError("delete constant")
+		}
 		return s.env.Delete(name)
 	case token.DOT:
 		idxE := node.(*ast.IndexExpression)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -460,9 +460,6 @@ func (s *State) evalDelete(node ast.Node) object.Object {
 	switch node.Value().Type() {
 	case token.IDENT:
 		name := node.Value().Literal()
-		if name == "" {
-			return s.NewError("delete empty identifier")
-		}
 		if object.Constant(name) {
 			return s.NewError("delete constant")
 		}

--- a/tests/delete.gr
+++ b/tests/delete.gr
@@ -73,7 +73,7 @@ func delConstTest() {
 }
 IsErr("del can't delete a constant", delConstTest(), "delete constant")
 IsErr("del can't delete a constant", del(GOLDENRATIO), "delete constant")
-IsOk("constant still exists", GOLDENRATIO,1.61803398875)
+NoErr("constant still exists", GOLDENRATIO, "1\\.6")
 
 map[PI] = PI
 map[GOLDENRATIO] = PI

--- a/tests/delete.gr
+++ b/tests/delete.gr
@@ -66,3 +66,17 @@ Assert("delTest2() should be true first time", delTest2())
 Assert("delTest2() should be false second time", delTest2() == false)
 Assert("entry is gone", map[1] == nil)
 Assert("entry is gone", len(map) == 2)
+
+GOLDENRATIO = 1.61803398875
+func delConstTest() {
+	del(GOLDENRATIO)
+}
+IsErr("del can't delete a constant", delConstTest(), "delete constant")
+IsErr("del can't delete a constant", del(GOLDENRATIO), "delete constant")
+Assert("constant still exists",GOLDENRATIO != nil)
+
+map[PI] = PI
+map[GOLDENRATIO] = PI
+Assert("still can delete map key if constant",del(map[PI])==true)
+Assert("still can delete map key if constant",del(map[GOLDENRATIO])==true)
+Assert("still can delete map key if constant",len(map)==2)

--- a/tests/delete.gr
+++ b/tests/delete.gr
@@ -73,7 +73,7 @@ func delConstTest() {
 }
 IsErr("del can't delete a constant", delConstTest(), "delete constant")
 IsErr("del can't delete a constant", del(GOLDENRATIO), "delete constant")
-Assert("constant still exists",GOLDENRATIO != nil)
+IsOk("constant still exists", GOLDENRATIO,1.61803398875)
 
 map[PI] = PI
 map[GOLDENRATIO] = PI


### PR DESCRIPTION
in evalDelete, use object.Constant to check if the node being deleted is a constant. returns error instead of deleting if so.

Fixes #303 