### PR TITLE
Workaround for paste, fix bug in regexp, show tclock cmdline

### DIFF
--- a/examples/dog_years.gr
+++ b/examples/dog_years.gr
@@ -1,16 +1,20 @@
 #! /usr/bin/env grol -quiet -s
 println("Dog Years Calculator")
-println(info.globals)
 if !info.globals.args {
 	println("### To run, use ./dog_years.gr")
 	return
 }
 print("Enter dog birthday: ")
 dogbday := read()
+println()
+printf("read %q\n", dogbday)
+// workaround for bracketed paste issue https://github.com/grol-io/grol/issues/418
+clean := regsub("\x1b\\[20[01]~", dogbday, "")
+printf("cleaned to %q\n", clean)
 
-bday = time.parse(trim(dogbday))
+bday = time.parse(trim(clean))
 
-println(time.info(bday))
+println("Parsed as", time.info(bday))
 
 now := time.now()
 age := now - bday
@@ -29,3 +33,5 @@ println("100 dog years is ", time.info(to100).str)
 
 delta := (to100 - now) / 86400
 println("Time until 100 dog years: ", delta, " days")
+
+printf("tclock -text \"Countdown to 100 years old\" -countdown %fh\n", delta*24)

--- a/extensions/extension.go
+++ b/extensions/extension.go
@@ -468,7 +468,7 @@ func createStrFunctions() { //nolint:funlen,gocognit,maintidx // we do have quit
 	strFn.Name = "regsub"
 	strFn.Help = "regexp, input, subst"
 	strFn.ArgTypes = []object.Type{object.STRING, object.STRING, object.STRING}
-	strFn.MaxArgs = 3
+	strFn.MinArgs = 3
 	strFn.Callback = func(env any, _ string, args []object.Object) object.Object {
 		s := env.(*eval.State)
 		regx := args[0].(object.String).Value


### PR DESCRIPTION
regexp max args was wrong, 3rd arg is not optional, was causing out of bounds exception

and workaround #418 by cleaning by hand 